### PR TITLE
ci: repair broken workflow and establish a green test baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings: store text as LF in git, check out LF everywhere.
+# Keeps Prettier's `endOfLine: "lf"` rule truthful for Windows contributors.
+* text=auto eol=lf
+
+# Binary assets — never touch.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.pdf binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, format]
+    needs: [lint, format]
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -77,4 +77,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
-      - run: bunx vitest run --passWithNoTests
+      - run: CI=true bun run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ bun run dev          # http://localhost:3000
 
 ## Stack
 
-React 18
+React 19
 
 ## Commit format
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Live Demo](https://img.shields.io/badge/Live-dentrw.vercel.app-blue?style=flat-square)](https://dentrw.vercel.app)
 [![v4 Live](https://img.shields.io/badge/v4-dentrw.hbapte.com-6366f1?style=flat-square)](https://dentrw.hbapte.com)
-[![Built with React](https://img.shields.io/badge/React-18-61dafb?style=flat-square&logo=react)](https://react.dev)
+[![Built with React](https://img.shields.io/badge/React-19-61dafb?style=flat-square&logo=react)](https://react.dev)
 [![Deployed on Vercel](https://img.shields.io/badge/Deploy-Vercel-000000?style=flat-square&logo=vercel)](https://vercel.com)
 [![JavaScript](https://img.shields.io/badge/JavaScript-ES6+-f7df1e?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 ![GitHub Repo Views](https://gitviews.com/repo/hbapte/dentrw-alx.svg?label-color=green&style=flat-square)
@@ -44,7 +44,7 @@ DentRW is a responsive web application for a dental clinic, built as the ALX Sof
 
 | Tool                                             | Purpose                                         |
 | ------------------------------------------------ | ----------------------------------------------- |
-| [React 18](https://react.dev)                    | Component-based UI framework                    |
+| [React 19](https://react.dev)                    | Component-based UI framework                    |
 | [Tailwind CSS](https://tailwindcss.com)          | Utility-first styling                           |
 | [EmailJS](https://www.emailjs.com)               | Client-side email sending for appointment forms |
 | [ConvertKit](https://convertkit.com)             | Newsletter subscription management              |

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import { render, screen } from "@testing-library/react"
-
-import App from "./App"
-
-test("renders learn react link", () => {
-  render(<App />)
-  const linkElement = screen.getByText(/learn react/i)
-  expect(linkElement).toBeInTheDocument()
-})

--- a/src/components/AnnouncementBar.test.js
+++ b/src/components/AnnouncementBar.test.js
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react"
+
+import AnnouncementBar from "./AnnouncementBar"
+
+test("shows the v4 announcement", () => {
+  render(<AnnouncementBar />)
+  expect(screen.getByText(/new features and improvements/i)).toBeInTheDocument()
+})
+
+test("links to the v4 site in a new tab", () => {
+  render(<AnnouncementBar />)
+  const link = screen.getByRole("link", { name: /explore now/i })
+  expect(link).toHaveAttribute("href", "https://dentrw.hbapte.com")
+  expect(link).toHaveAttribute("target", "_blank")
+  expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"))
+})

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,35 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
+// jest-dom adds custom matchers for asserting on DOM nodes.
+// https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom"
+
+// --- jsdom polyfills for browser APIs used by third-party UI libs ---
+// (swiper, react-awesome-reveal)
+
+if (!window.matchMedia) {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })
+}
+
+class MockObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return []
+  }
+}
+
+if (!window.IntersectionObserver) {
+  window.IntersectionObserver = MockObserver
+}
+if (!window.ResizeObserver) {
+  window.ResizeObserver = MockObserver
+}


### PR DESCRIPTION
## 📑 Description

CI has been failing on **every push** — the `test` job declared `needs: [lint, typecheck, format]` but there is no `typecheck` job, so GitHub Actions rejected the whole workflow (fails in 0s). As a result lint, format, audit, and test have never actually run. This PR repairs the pipeline and gives it one real test to guard.

Changes:

- [x] `ci.yml`: drop the non-existent `typecheck` from `needs:`; the `test` job now runs the real test runner (`CI=true bun run test`) instead of `bunx vitest run` (vitest isn't a dependency — the project uses `react-scripts test`)
- [x] Replace the placeholder `src/App.test.js` (it asserted "learn react", text that isn't in the app) with real specs in `src/components/AnnouncementBar.test.js`
- [x] Add jsdom polyfills (`matchMedia`, `IntersectionObserver`, `ResizeObserver`) to `setupTests.js` so component tests don't crash on Swiper / react-awesome-reveal
- [x] Docs: React 18 → 19 (badge, tech-stack table, `CONTRIBUTING.md`); add a `dev` script so the documented `bun run dev` works
- [x] Add `.gitattributes` (`* text=auto eol=lf`) so Prettier's `endOfLine: "lf"` rule is truthful for Windows contributors

**Note:** the full-`<App/>` render smoke test was intentionally dropped, not kept — CRA's Jest can't transform `axios`'s ESM, so `render(<App/>)` throws from inside `node_modules`. Full-app testing is straightforward to restore once the project moves to Vitest; for now the `AnnouncementBar` tests are the baseline.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

Local verification (all green): `bun run format` · `bun run lint` · `CI=true bun run test` (2 passed) · `CI=true bun run build` · commitlint on all commits.

## ℹ Additional Information

- No runtime/app behaviour changes — this is CI + test-infra + docs only.
- This is the first plan in a small enhancement roadmap; follow-ups (remove dead deps, migrate CRA → Vite, SEO/PWA, i18n) build on this green baseline.
- Some pre-existing files (`commitlint.config.mjs`, workflow YAML) may look "unformatted" when checked out on Windows with `core.autocrlf=true` — that's a line-ending illusion the new `.gitattributes` resolves; they pass Prettier on Linux CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development start command for easier local app launching.

* **Bug Fixes**
  * Improved test-environment compatibility for browser APIs.

* **Tests**
  * Added coverage for the announcement bar and its external link behavior.
  * Updated continuous integration test execution.

* **Documentation**
  * Updated React version references to React 19.

* **Chores**
  * Standardized text line endings and binary asset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->