### PR TITLE
feat: i18n foundation — react-i18next (en/fr) + language switcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,8 @@
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
         "husky": "^9.1.7",
+        "i18next": "^26.4.0",
+        "i18next-browser-languagedetector": "^8.2.1",
         "knip": "^6.17.1",
         "lint-staged": "^17.0.7",
         "oxlint": "^1.70.0",
@@ -22,6 +24,7 @@
         "react": "^19.0.0",
         "react-awesome-reveal": "^4.2.3",
         "react-dom": "^19.0.0",
+        "react-i18next": "^17.0.12",
         "react-scroll": "^1.8.9",
         "swiper": "^9.3.2",
       },
@@ -915,7 +918,13 @@
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
+    "html-parse-stringify": ["html-parse-stringify@4.0.1", "", {}, "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw=="],
+
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "i18next": ["i18next@26.4.0", "", { "peerDependencies": { "typescript": "^5 || ^6 || ^7" }, "optionalPeers": ["typescript"] }, "sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg=="],
+
+    "i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.1", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw=="],
 
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
@@ -1207,6 +1216,8 @@
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
+    "react-i18next": ["react-i18next@17.0.12", "", { "dependencies": { "@babel/runtime": "^7.29.7", "html-parse-stringify": "^4.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 26.2.0", "react": ">= 16.8.0", "react-dom": "*", "react-native": "*", "typescript": "^5 || ^6 || ^7" }, "optionalPeers": ["react-dom", "react-native", "typescript"] }, "sha512-lFWPEGkxQ6RhusdUkysFBD58VHfSSzvHBzqMgN0SvfVpdQGfwtNkStTqdy08/sJd7s807qqutgx93fRpD0DJ3Q=="],
+
     "react-intersection-observer": ["react-intersection-observer@9.16.0", "", { "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -1418,6 +1429,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -1677,6 +1690,8 @@
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "i18next-browser-languagedetector/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "internal-slot/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
@@ -1714,6 +1729,8 @@
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-i18next/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,91 @@
+# Internationalisation (i18n)
+
+DentRW ships English (`en`) and French (`fr`). This document is the convention
+for extending translation coverage.
+
+## Stack
+
+- **[i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/)** — runtime translation.
+- **[i18next-browser-languagedetector](https://github.com/i18next/i18next-browser-languageDetector)** — picks the language from `localStorage` (key `i18nextLng`), falling back to the browser's `navigator.language`, then to `en`.
+- Init lives in [`src/i18n/index.js`](../src/i18n/index.js) and is imported once, before `<App />`, in `src/index.jsx`.
+- There is **no URL-based locale** (`/fr/…`). The site is a single scrolling page; a runtime toggle is enough. Revisit if routing is ever added (then add `hreflang` tags too).
+
+## Files
+
+```
+src/i18n/
+  index.js                 init + SUPPORTED_LANGUAGES + <html lang> sync
+  locales/
+    en/common.json         source of truth
+    fr/common.json          must mirror en's key set
+```
+
+`<html lang>` is kept in sync with the active language automatically by a
+`languageChanged` handler in `src/i18n/index.js` — nothing to do per component.
+
+## Namespaces
+
+One JSON file per feature area under `src/i18n/locales/<lng>/<namespace>.json`.
+Only `common` exists today. When a component needs its own namespace (e.g.
+`contact`, `services`), add `contact.json` under **both** `en/` and `fr/`, and
+register it in `src/i18n/index.js`:
+
+```js
+import enContact from "./locales/en/contact.json"
+import frContact from "./locales/fr/contact.json"
+// ...
+resources: {
+  en: { common: enCommon, contact: enContact },
+  fr: { common: frCommon, contact: frContact },
+}
+```
+
+Then `useTranslation("contact")` in the component.
+
+## Key naming
+
+`section.element` or `section.element.variant` — lowercase, dot-separated.
+Example: `contact.form.fullNameLabel`, `hero.headline`.
+
+## Converting a component
+
+1. `import { useTranslation } from "react-i18next"` and call `const { t } = useTranslation()` (or `useTranslation("<namespace>")`).
+2. Replace each hardcoded user-facing string with `t("some.key")`.
+3. Add the key + **English** value to the matching `en/<ns>.json`.
+4. Add the same key to `fr/<ns>.json` with the French translation (or, if a
+   translator isn't available yet, the English value as a placeholder — never
+   leave a key missing, or that locale renders the raw key).
+5. Keep the `en` and `fr` key sets identical.
+
+`AnnouncementBar.jsx` is the worked example — see it and
+`src/i18n/locales/*/common.json`.
+
+## Finding untranslated / missing keys
+
+Run the app in dev; i18next logs missing keys to the console. For a stricter
+pass, temporarily set `saveMissing: true` + a `missingKeyHandler` in
+`src/i18n/index.js`.
+
+## What NOT to translate
+
+- User-generated content — the testimonial quotes in `Testimonials.jsx` stay in
+  their original language.
+- The brand name "DentRW", external URLs, phone numbers, email addresses.
+
+## Remaining components (rough string counts, suggested order)
+
+| Component          | ~strings | Notes                                          |
+| ------------------ | -------: | ---------------------------------------------- |
+| `Navbar.jsx`       |       15 | nav labels + logo alt                          |
+| `Hero.jsx`         |       10 | headline, sub-copy, CTAs                       |
+| `Services.jsx`     |       20 | service names + blurbs                         |
+| `Insurance.jsx`    |        5 | heading + partner labels                       |
+| `Features.jsx`     |       15 |                                                |
+| `Team.jsx`         |       10 | names stay; roles translate                    |
+| `FAQs.jsx`         |       20 | Q + A pairs                                    |
+| `Contact.jsx`      |       30 | form labels, clinic hours, service `<option>`s |
+| `Footer.jsx`       |       40 | newsletter copy, link columns                  |
+| `Testimonials.jsx` |       10 | UI chrome only — leave quotes                  |
+| `Sign.jsx`         |       15 | login stub (only if wired up)                  |
+
+Each is an independent, low-risk PR following the steps above.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "baseline-browser-mapping": "^2.10.38",
     "caniuse-lite": "^1.0.30001799",
     "husky": "^9.1.7",
+    "i18next": "^26.4.0",
+    "i18next-browser-languagedetector": "^8.2.1",
     "knip": "^6.17.1",
     "lint-staged": "^17.0.7",
     "oxlint": "^1.70.0",
@@ -20,6 +22,7 @@
     "react": "^19.0.0",
     "react-awesome-reveal": "^4.2.3",
     "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.12",
     "react-scroll": "^1.8.9",
     "swiper": "^9.3.2"
   },

--- a/plans/README.md
+++ b/plans/README.md
@@ -23,7 +23,7 @@ migration, then build on it (SEO/PWA, i18n).
 | 002  | Remove dead code — unused deps and orphan files       | P1       | S      | 001        | DONE   |
 | 003  | Migrate from Create React App to Vite + Vitest        | P1       | L      | 001, 002   | DONE   |
 | 004  | SEO essentials + installable PWA                      | P2       | M      | 003        | DONE   |
-| 005  | i18n foundation — react-i18next setup + first slice   | P2       | M      | 003        | TODO   |
+| 005  | i18n foundation — react-i18next setup + first slice   | P2       | M      | 003        | DONE   |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale)
 
@@ -70,5 +70,9 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED 
 - After **004** merges: run the built `index.html` through Google's Rich Results
   Test and a Lighthouse SEO/PWA audit; design a real 1200×630 OG image to
   replace the placeholder.
-- **005** ships `en` complete with `rw`/`fr` stubbed to English placeholders —
-  real Kinyarwanda/French copy is a separate content task (see `docs/i18n.md`).
+- **005** shipped **English + French only** (Kinyarwanda dropped per maintainer
+  decision). French is fully translated for the converted strings, not stubbed.
+  Extending coverage to the remaining ~13 components is the phased follow-up in
+  `docs/i18n.md`. Config note: `load: "languageOnly"` +
+  `nonExplicitSupportedLngs: true` so a browser set to `en-US` / `fr-FR` maps to
+  `en` / `fr` correctly.

--- a/src/components/AnnouncementBar.jsx
+++ b/src/components/AnnouncementBar.jsx
@@ -1,15 +1,18 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 
 const AnnouncementBar = () => {
+  const { t } = useTranslation()
+
   return (
     <div className="fixed top-0 left-0 w-full z-50 bg-blue-600 text-white text-sm text-center py-2 px-4">
-      DentRW v4 is here with new features and improvements.{" "}
+      {t("announcement.message")}{" "}
       <a
         href="https://dentrw.hbapte.com"
         target="_blank"
         rel="noopener noreferrer"
         className="underline font-semibold hover:text-blue-200 transition-colors">
-        Explore now &rarr;
+        {t("announcement.cta")} &rarr;
       </a>
     </div>
   )

--- a/src/components/AnnouncementBar.test.jsx
+++ b/src/components/AnnouncementBar.test.jsx
@@ -1,6 +1,11 @@
 import { render, screen } from "@testing-library/react"
 
+import i18n from "../i18n"
 import AnnouncementBar from "./AnnouncementBar"
+
+afterEach(async () => {
+  await i18n.changeLanguage("en")
+})
 
 test("shows the v4 announcement", () => {
   render(<AnnouncementBar />)
@@ -13,4 +18,11 @@ test("links to the v4 site in a new tab", () => {
   expect(link).toHaveAttribute("href", "https://dentrw.hbapte.com")
   expect(link).toHaveAttribute("target", "_blank")
   expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"))
+})
+
+test("renders the French copy when the language is French", async () => {
+  await i18n.changeLanguage("fr")
+  render(<AnnouncementBar />)
+  expect(screen.getByText(/nouvelles fonctionnalités/i)).toBeInTheDocument()
+  expect(screen.getByRole("link", { name: /découvrir/i })).toBeInTheDocument()
 })

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+
+import { SUPPORTED_LANGUAGES } from "../i18n"
+
+const LanguageSwitcher = () => {
+  const { i18n, t } = useTranslation()
+  const current = i18n.resolvedLanguage
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      role="group"
+      aria-label={t("language.label")}>
+      {SUPPORTED_LANGUAGES.map((lng) => (
+        <button
+          key={lng}
+          type="button"
+          onClick={() => i18n.changeLanguage(lng)}
+          aria-current={current === lng ? "true" : undefined}
+          className={
+            "rounded px-2 py-1 text-xs font-semibold uppercase transition-colors " +
+            (current === lng
+              ? "bg-blue-600 text-white"
+              : "text-blue-900 hover:bg-blue-50")
+          }>
+          {lng}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default LanguageSwitcher

--- a/src/components/LanguageSwitcher.test.jsx
+++ b/src/components/LanguageSwitcher.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import i18n from "../i18n"
+import LanguageSwitcher from "./LanguageSwitcher"
+
+afterEach(async () => {
+  await i18n.changeLanguage("en")
+})
+
+test("renders a button per supported language", () => {
+  render(<LanguageSwitcher />)
+  expect(screen.getByRole("button", { name: "en" })).toBeInTheDocument()
+  expect(screen.getByRole("button", { name: "fr" })).toBeInTheDocument()
+})
+
+test("changes the active language on click", async () => {
+  const user = userEvent.setup()
+  render(<LanguageSwitcher />)
+  await user.click(screen.getByRole("button", { name: "fr" }))
+  expect(i18n.resolvedLanguage).toBe("fr")
+})

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react"
 import { Link, animateScroll as scroll } from "react-scroll"
 
+import LanguageSwitcher from "./LanguageSwitcher"
+
 const Navbar = () => {
   const [showNavbar, setShowNavbar] = useState(false)
   const [showMenu, setShowMenu] = useState(false)
@@ -101,6 +103,9 @@ const Navbar = () => {
               </Link>
             </li>
           ))}
+          <li>
+            <LanguageSwitcher />
+          </li>
         </ul>
       </nav>
 
@@ -137,6 +142,9 @@ const Navbar = () => {
                 </Link>
               </li>
             ))}
+            <li className="mt-1 px-4 py-2">
+              <LanguageSwitcher />
+            </li>
           </ul>
         )}
       </div>

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,41 @@
+import i18n from "i18next"
+import LanguageDetector from "i18next-browser-languagedetector"
+import { initReactI18next } from "react-i18next"
+
+import enCommon from "./locales/en/common.json"
+import frCommon from "./locales/fr/common.json"
+
+export const SUPPORTED_LANGUAGES = ["en", "fr"]
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { common: enCommon },
+      fr: { common: frCommon },
+    },
+    fallbackLng: "en",
+    supportedLngs: SUPPORTED_LANGUAGES,
+    // Treat region variants (e.g. "en-US", "fr-FR") as their base language
+    // so the browser's preferred language is matched correctly.
+    load: "languageOnly",
+    nonExplicitSupportedLngs: true,
+    defaultNS: "common",
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ["localStorage", "navigator"],
+      caches: ["localStorage"],
+    },
+  })
+
+// Keep <html lang> in sync with the active language.
+const applyHtmlLang = (lng) => {
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = lng
+  }
+}
+applyHtmlLang(i18n.resolvedLanguage || "en")
+i18n.on("languageChanged", applyHtmlLang)
+
+export default i18n

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,0 +1,11 @@
+{
+  "announcement": {
+    "message": "DentRW v4 is here with new features and improvements.",
+    "cta": "Explore now"
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "fr": "Français"
+  }
+}

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1,0 +1,11 @@
+{
+  "announcement": {
+    "message": "DentRW v4 est arrivé, avec de nouvelles fonctionnalités et améliorations.",
+    "cta": "Découvrir"
+  },
+  "language": {
+    "label": "Langue",
+    "en": "English",
+    "fr": "Français"
+  }
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,7 @@ import React from "react"
 import ReactDOM from "react-dom/client"
 
 import "./index.css"
+import "./i18n"
 
 import App from "./App"
 


### PR DESCRIPTION
## 📑 Description

Foundation for multilingual support (README roadmap item). Wires up **react-i18next** with **English + French**, adds a language switcher, and converts one component end-to-end as the reference pattern. It deliberately stops there — extending coverage to the rest is a phased, mechanical follow-up documented in `docs/i18n.md`.

- [x] `i18next` + `react-i18next` + `i18next-browser-languagedetector`
- [x] `src/i18n/index.js` — init, `SUPPORTED_LANGUAGES`, language persisted in `localStorage`, `<html lang>` synced to the active language. `load: "languageOnly"` + `nonExplicitSupportedLngs: true` so a browser set to `en-US` / `fr-FR` resolves correctly.
- [x] `src/i18n/locales/{en,fr}/common.json` — French is **actually translated**, not stubbed
- [x] `<LanguageSwitcher>` (EN / FR) mounted in the navbar (desktop + mobile menu)
- [x] `AnnouncementBar.jsx` converted to `useTranslation()` — the worked example
- [x] `docs/i18n.md` — the extraction convention + the remaining ~13 components with rough string counts and suggested order
- [x] Tests: `LanguageSwitcher.test.jsx` (renders both buttons; click changes language), `AnnouncementBar.test.jsx` extended with a French-copy assertion

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

**Verified** in a browser (`bun run dev`): switching EN ↔ FR updates the announcement copy, sets `<html lang>`, and persists across reload. Fresh visit with `navigator.language = en-US` resolves to English. `bun run build` / `test` (5 passing) / `lint` / `format` all green.

## ℹ Additional Information

- Only `AnnouncementBar` is translated in this PR — every other component keeps its hardcoded English (per the "foundation only" scope). The rest is `docs/i18n.md`'s to-do list, one small PR per component.
- No URL-based locale (`/fr/…`) — the site is one scrolling page, so a runtime toggle is enough. Revisit with `hreflang` if routing is ever added.
- Testimonial quotes stay in their original language (user-generated content).
- Last plan in the roadmap (`plans/README.md`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added English and French language support.
  - Added a language switcher to desktop and mobile navigation.
  - Language preferences are detected automatically and saved for future visits.
  - Updated the announcement banner with translated messages and call-to-action text.
  - Browser language variants such as `en-US` and `fr-FR` are supported.

- **Documentation**
  - Added guidance covering translation structure, workflows, and remaining localization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->