### PR TITLE
refactor: use proper JSX attribute names (className, htmlFor, camelCase SVG)

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -53,7 +53,7 @@ const Contact = () => {
           <h3 className="text-3xl sm:text-4xl leading-normal font-extrabold tracking-tight">
             Get In <span className="text-[#3b82f6]">Touch</span>
           </h3>
-          <p class="mt-4 leading-6 text-gray-950">
+          <p className="mt-4 leading-6 text-gray-950">
             Book an appointment with our doctors, Our team is ready and waiting
             to serve you.
           </p>
@@ -113,11 +113,11 @@ const Contact = () => {
         <form
           ref={form}
           onSubmit={sendEmail}
-          class="md:col-span-8 px-10 pt-4 pb-3">
-          <div class="mb-3 " name="contact" id="contact">
+          className="md:col-span-8 px-10 pt-4 pb-3">
+          <div className="mb-3 " name="contact" id="contact">
             <label
-              for="user_name"
-              class="mb-1 block text-base font-medium text-[#07074D]">
+              htmlFor="user_name"
+              className="mb-1 block text-base font-medium text-[#07074D]">
               Full Name
             </label>
             <input
@@ -125,17 +125,17 @@ const Contact = () => {
               name="user_name"
               id="user_name"
               placeholder="Full Name"
-              class="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
+              className="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
               required
             />
           </div>
 
-          <div class="-mx-3 flex flex-wrap">
-            <div class="w-full px-3 sm:w-1/2">
-              <div class="mb-3">
+          <div className="-mx-3 flex flex-wrap">
+            <div className="w-full px-3 sm:w-1/2">
+              <div className="mb-3">
                 <label
-                  for="user_phone"
-                  class="mb-1 block text-base font-medium text-[#07074D]">
+                  htmlFor="user_phone"
+                  className="mb-1 block text-base font-medium text-[#07074D]">
                   Phone Number
                 </label>
                 <input
@@ -143,16 +143,16 @@ const Contact = () => {
                   name="user_phone"
                   id="user_phone"
                   placeholder="Enter your phone number"
-                  class="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
+                  className="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
                   required
                 />
               </div>
             </div>
-            <div class="w-full px-3 sm:w-1/2">
-              <div class="mb-3">
+            <div className="w-full px-3 sm:w-1/2">
+              <div className="mb-3">
                 <label
-                  for="user_email"
-                  class="mb-1 block text-base font-medium text-[#07074D]">
+                  htmlFor="user_email"
+                  className="mb-1 block text-base font-medium text-[#07074D]">
                   Email Address
                 </label>
                 <input
@@ -160,23 +160,23 @@ const Contact = () => {
                   name="user_email"
                   id="user_email"
                   placeholder="Enter your email"
-                  class="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
+                  className="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
                   required
                 />
               </div>
             </div>
           </div>
 
-          <div class="-mx-0 mb-3">
+          <div className="-mx-0 mb-3">
             <label
-              for="chosen_service"
-              class="mb-1 block text-base font-medium text-[#07074D]">
+              htmlFor="chosen_service"
+              className="mb-1 block text-base font-medium text-[#07074D]">
               Dental Services
             </label>
             <select
               name="chosen_service"
               id="chosen_service"
-              class="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md">
+              className="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md">
               <option value="checkup_Consultation">
                 Dental Check-ups and Consultation
               </option>
@@ -193,34 +193,34 @@ const Contact = () => {
             </select>
           </div>
 
-          <div class="-mx-3 flex flex-wrap">
-            <div class="w-full px-3 sm:w-1/2">
-              <div class="mb-3">
+          <div className="-mx-3 flex flex-wrap">
+            <div className="w-full px-3 sm:w-1/2">
+              <div className="mb-3">
                 <label
-                  for="user_date"
-                  class="mb-1 block text-base font-medium text-[#07074D]">
+                  htmlFor="user_date"
+                  className="mb-1 block text-base font-medium text-[#07074D]">
                   Date
                 </label>
                 <input
                   type="date"
                   name="user_date"
                   id="user_date"
-                  class="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
+                  className="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
                 />
               </div>
             </div>
-            <div class="w-full px-3 sm:w-1/2">
-              <div class="mb-3">
+            <div className="w-full px-3 sm:w-1/2">
+              <div className="mb-3">
                 <label
-                  for="user_time"
-                  class="mb-1 block text-base font-medium text-[#07074D]">
+                  htmlFor="user_time"
+                  className="mb-1 block text-base font-medium text-[#07074D]">
                   Time
                 </label>
                 <input
                   type="time"
                   name="user_time"
                   id="user_time"
-                  class="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
+                  className="w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md"
                 />
               </div>
             </div>
@@ -229,7 +229,7 @@ const Contact = () => {
           <div className="w-full mb-3">
             <label
               className="mb-1 block text-base font-medium text-[#07074D]"
-              for="user_message">
+              htmlFor="user_message">
               Doctor Note
             </label>
             <textarea

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -58,8 +58,8 @@ const Footer = () => {
   return (
     <footer className="px-4  bg-[#0A2540] text-white">
       <div className="mt-6 pt-6 flex ">
-        <div class="mb-4 ">
-          <h2 class="text-xl font-bold text-slate-100">
+        <div className="mb-4 ">
+          <h2 className="text-xl font-bold text-slate-100">
             Subscribe to our newsletter!
           </h2>
         </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -7,26 +7,26 @@ import homepicture from "./Images/home.png"
 const Hero = () => {
   return (
     <main>
-      <div class="" name="home">
-        <div class="mx-auto h-full px-4 py-10 sm:max-w-xl md:max-w-full md:px-24 md:py-36 lg:px-8">
-          <div class="flex flex-col items-center justify-between lg:flex-row">
-            <div class="">
-              <div class="lg:max-w-xl lg:pr-5">
-                <h2 class="md:mt-0 mt-24  mb-6 max-w-lg text-5xl font-light leading-snug tracking-tight text-blue-600 sm:text-8xl">
+      <div className="" name="home">
+        <div className="mx-auto h-full px-4 py-10 sm:max-w-xl md:max-w-full md:px-24 md:py-36 lg:px-8">
+          <div className="flex flex-col items-center justify-between lg:flex-row">
+            <div className="">
+              <div className="lg:max-w-xl lg:pr-5">
+                <h2 className="md:mt-0 mt-24  mb-6 max-w-lg text-5xl font-light leading-snug tracking-tight text-blue-600 sm:text-8xl">
                   Meet your <br />
-                  <span class="my-1 inline-block border-b-8 border-blue-600 font-bold text-blue-600">
+                  <span className="my-1 inline-block border-b-8 border-blue-600 font-bold text-blue-600">
                     {" "}
                     Dentist{" "}
                   </span>
                 </h2>
 
-                <p class="text-base text-gray-700">
+                <p className="text-base text-gray-700">
                   Harmonizing Oral health and creating beautiful smiles.
                   Bringing confidence and wellness to your life through modern
                   dental care!
                 </p>
               </div>
-              <div class="mt-10 flex flex-col items-center md:flex-row">
+              <div className="mt-10 flex flex-col items-center md:flex-row">
                 <Link
                   to="contact"
                   smooth={true}
@@ -44,18 +44,18 @@ const Hero = () => {
                   Get Started
                 </Link>
               </div>
-              <div class="mt-12 flex flex-col space-y-3 divide-gray-300 text-sm text-gray-700 sm:flex-row sm:space-y-0 sm:divide-x">
-                <div class="flex max-w-xs space-x-2 px-4">
+              <div className="mt-12 flex flex-col space-y-3 divide-gray-300 text-sm text-gray-700 sm:flex-row sm:space-y-0 sm:divide-x">
+                <div className="flex max-w-xs space-x-2 px-4">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    class="h-12 w-12 text-emerald-600"
+                    className="h-12 w-12 text-emerald-600"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
-                    stroke-width="2">
+                    strokeWidth="2">
                     <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
                       d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
                     />
                   </svg>
@@ -64,17 +64,17 @@ const Hero = () => {
                     care
                   </p>
                 </div>
-                <div class="flex max-w-xs space-x-2 px-4">
+                <div className="flex max-w-xs space-x-2 px-4">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    class="h-12 w-12 text-blue-600"
+                    className="h-12 w-12 text-blue-600"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
-                    stroke-width="2">
+                    strokeWidth="2">
                     <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
                       d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
                     />
                   </svg>
@@ -82,45 +82,49 @@ const Hero = () => {
                 </div>
               </div>
             </div>
-            <div class="relative hidden lg:ml-32 lg:block lg:w-1/2">
+            <div className="relative hidden lg:ml-32 lg:block lg:w-1/2">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="mx-auto my-6 h-10 w-10 animate-bounce rounded-full bg-blue-50 p-2 lg:hidden"
+                className="mx-auto my-6 h-10 w-10 animate-bounce rounded-full bg-blue-50 p-2 lg:hidden"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
-                stroke-width="2">
+                strokeWidth="2">
                 <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                   d="M16 17l-4 4m0 0l-4-4m4 4V3"
                 />
               </svg>
-              <div class="w-fit rounded-[6rem] mx-auto overflow-hidden rounded-tl-none rounded-br-none bg-blue-400">
+              <div className="w-fit rounded-[6rem] mx-auto overflow-hidden rounded-tl-none rounded-br-none bg-blue-400">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  class="absolute -left-10 -top-20 h-28 w-28 rounded-xl bg-white text-gray-400"
+                  className="absolute -left-10 -top-20 h-28 w-28 rounded-xl bg-white text-gray-400"
                   viewBox="0 0 20 20"
                   fill="currentColor">
                   <path
-                    fill-rule="evenodd"
+                    fillRule="evenodd"
                     d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z"
-                    clip-rule="evenodd"
+                    clipRule="evenodd"
                   />
                 </svg>
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  class="absolute right-0 -bottom-20 h-28 w-28 rounded-xl bg-white text-gray-400"
+                  className="absolute right-0 -bottom-20 h-28 w-28 rounded-xl bg-white text-gray-400"
                   viewBox="0 0 20 20"
                   fill="currentColor">
                   <path
-                    fill-rule="evenodd"
+                    fillRule="evenodd"
                     d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z"
-                    clip-rule="evenodd"
+                    clipRule="evenodd"
                   />
                 </svg>
                 <Fade>
-                  <img class="-mb-20" src={homepicture} alt="hero portrait" />
+                  <img
+                    className="-mb-20"
+                    src={homepicture}
+                    alt="hero portrait"
+                  />
                 </Fade>
               </div>
             </div>

--- a/src/components/Insurance.jsx
+++ b/src/components/Insurance.jsx
@@ -13,7 +13,7 @@ import SORAS from "./Images/insurance/Soras.png"
 const Insurance = () => {
   return (
     <section className="mt-16 " id="insurance">
-      <header class="">
+      <header className="">
         <Fade>
           <div className="max-w-xl mb-10 mx-4 md:mx-auto  sm:text-center lg:max-w-2xl md:mb-12">
             <div>
@@ -49,13 +49,13 @@ const Insurance = () => {
               companies for your coverage
             </h2>
 
-            <p class="max-w-[40rem] text-md mx-auto mt-4 text-gray-500"></p>
+            <p className="max-w-[40rem] text-md mx-auto mt-4 text-gray-500"></p>
           </div>
         </Fade>
       </header>
-      <div class="slider grid grid-cols-4 lg:grid-cols-8   shadow-md opacity-[100%] h-100 mx-auto overflow-hidden relative ">
-        {/* <div class="slide-track animate-scroll"> */}
-        <div class="slide h-100 w-250">
+      <div className="slider grid grid-cols-4 lg:grid-cols-8   shadow-md opacity-[100%] h-100 mx-auto overflow-hidden relative ">
+        {/* <div className="slide-track animate-scroll"> */}
+        <div className="slide h-100 w-250">
           <img
             src={RSSB}
             className="object-cover"
@@ -64,27 +64,27 @@ const Insurance = () => {
             alt=""
           />
         </div>
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={SANLAM} height="100" width="250" alt="" />
         </div>
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={MMI} height="10" width="250" alt="" />
         </div>
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={BRITAM} className="" alt="" />
         </div>
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={SORAS} height="100" width="250" alt="" />
         </div>
 
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={PRIME} height="100" width="250" alt="Prime Insurance" />
         </div>
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={RADIANT} height="50" width="250" alt="" />
         </div>
 
-        <div class="slide h-100 w-250">
+        <div className="slide h-100 w-250">
           <img src={BK} height="100" width="250" alt="" />
         </div>
       </div>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -13,8 +13,8 @@ import Xray from "./Images/xray.jpeg"
 const Services = () => {
   return (
     <section className="px-5 " id="service">
-      <div class=" ">
-        <header class="">
+      <div className=" ">
+        <header className="">
           <Fade>
             <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <div>
@@ -50,7 +50,7 @@ const Services = () => {
                 we offers
               </h2>
 
-              <p class="max-w-[40rem] text-md mx-auto mt-4 text-gray-500">
+              <p className="max-w-[40rem] text-md mx-auto mt-4 text-gray-500">
                 DentRw provide a comprehensive suite of dental services
                 including General, Cosmetic, Restorative, Pediatric and
                 Emergency Dentistry.
@@ -59,13 +59,13 @@ const Services = () => {
           </Fade>
         </header>
 
-        <ul class="grid gap-4 h-30 mt-6 sm:grid-cols-2   lg:grid-cols-4 ">
+        <ul className="grid gap-4 h-30 mt-6 sm:grid-cols-2   lg:grid-cols-4 ">
           <Fade>
             <li className="bg-slate-200 ">
-              <img src={Service1} alt="" class="" />
+              <img src={Service1} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Cleaning & Teeth whitening
                 </h3>
               </div>
@@ -74,20 +74,20 @@ const Services = () => {
 
           <Fade>
             <li className="bg-slate-200 ">
-              <img src={Xray} alt="" class="" />
+              <img src={Xray} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 ">X-ray</h3>
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 ">X-ray</h3>
               </div>
             </li>
           </Fade>
 
           <Fade>
             <li className="bg-slate-200">
-              <img src={Ortho} alt="" class="" />
+              <img src={Ortho} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Orthodontic Treatment
                 </h3>
               </div>
@@ -95,10 +95,10 @@ const Services = () => {
           </Fade>
           <Fade>
             <li className="bg-slate-200 ">
-              <img src={Bridge} alt="" class="" />
+              <img src={Bridge} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Dental Bridge
                 </h3>
               </div>
@@ -106,10 +106,10 @@ const Services = () => {
           </Fade>
           <Fade>
             <li className="bg-slate-200">
-              <img src={Toothache} alt="" class="" />
+              <img src={Toothache} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Toothache relief
                 </h3>
               </div>
@@ -117,10 +117,10 @@ const Services = () => {
           </Fade>
           <Fade>
             <li className="bg-slate-200">
-              <img src={Extraction} alt="" class="" />
+              <img src={Extraction} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Extraction
                 </h3>
               </div>
@@ -128,10 +128,10 @@ const Services = () => {
           </Fade>
           <Fade>
             <li className="bg-slate-200">
-              <img src={RootCanal} alt="" class="" />
+              <img src={RootCanal} alt="" className="" />
 
-              <div class="relative py-2">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Root Canal Treatment
                 </h3>
               </div>
@@ -139,10 +139,10 @@ const Services = () => {
           </Fade>
           <Fade>
             <li className="bg-slate-200 rounded-[4px]">
-              <img src={Consultation} alt="" class=" " />
+              <img src={Consultation} alt="" className=" " />
 
-              <div class="relative py-2 ">
-                <h3 class="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+              <div className="relative py-2 ">
+                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
                   Check-ups and Consultation
                 </h3>
               </div>

--- a/src/components/Sign.jsx
+++ b/src/components/Sign.jsx
@@ -3,44 +3,44 @@ import React from "react"
 const Sign = () => {
   return (
     <div>
-      <div class="mx-auto max-w-screen-xl px-4 py-8 sm:px-6 lg:px-8">
-        <div class="mx-auto max-w-lg">
-          <h1 class="text-center text-2xl font-bold text-indigo-600 sm:text-3xl">
+      <div className="mx-auto max-w-screen-xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-lg">
+          <h1 className="text-center text-2xl font-bold text-indigo-600 sm:text-3xl">
             Get started today
           </h1>
           <form
             action="./login"
             method="post"
-            class="mb-0 mt-6 space-y-4 rounded-lg p-4 shadow-lg sm:p-6 lg:p-8">
-            <p class="text-center text-lg font-medium">
+            className="mb-0 mt-6 space-y-4 rounded-lg p-4 shadow-lg sm:p-6 lg:p-8">
+            <p className="text-center text-lg font-medium">
               Sign in to your account
             </p>
 
             <div>
-              <label for="email" class="sr-only">
+              <label htmlFor="email" className="sr-only">
                 Email
               </label>
 
-              <div class="relative">
+              <div className="relative">
                 <input
                   id="email"
                   name="email"
                   type="email"
-                  class="w-full rounded-lg border-gray-200 p-4 pe-12 text-sm shadow-sm"
+                  className="w-full rounded-lg border-gray-200 p-4 pe-12 text-sm shadow-sm"
                   placeholder="Enter email"
                 />
 
-                <span class="absolute inset-y-0 end-0 grid place-content-center px-4">
+                <span className="absolute inset-y-0 end-0 grid place-content-center px-4">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    class="h-4 w-4 text-gray-400"
+                    className="h-4 w-4 text-gray-400"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
                       d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"
                     />
                   </svg>
@@ -49,36 +49,36 @@ const Sign = () => {
             </div>
 
             <div>
-              <label for="password" class="sr-only">
+              <label htmlFor="password" className="sr-only">
                 Password
               </label>
 
-              <div class="relative">
+              <div className="relative">
                 <input
                   type="password"
                   id="password"
                   name="password"
-                  class="w-full rounded-lg border-gray-200 p-4 pe-12 text-sm shadow-sm"
+                  className="w-full rounded-lg border-gray-200 p-4 pe-12 text-sm shadow-sm"
                   placeholder="Enter password"
                 />
 
-                <span class="absolute inset-y-0 end-0 grid place-content-center px-4">
+                <span className="absolute inset-y-0 end-0 grid place-content-center px-4">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    class="h-4 w-4 text-gray-400"
+                    className="h-4 w-4 text-gray-400"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
                       d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
                     />
                     <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
                       d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                     />
                   </svg>
@@ -86,64 +86,70 @@ const Sign = () => {
               </div>
             </div>
 
-            <div class="text-right mt-0">
+            <div className="text-right mt-0">
               <a
                 href="/"
-                class="text-xs font-semibold text-gray-700 hover:text-blue-700 focus:text-blue-700">
+                className="text-xs font-semibold text-gray-700 hover:text-blue-700 focus:text-blue-700">
                 Forgot Password?
               </a>
             </div>
 
             <button
               type="submit"
-              class="block w-full rounded-lg bg-indigo-600 px-5 py-3 text-sm font-medium text-white">
+              className="block w-full rounded-lg bg-indigo-600 px-5 py-3 text-sm font-medium text-white">
               Sign in
             </button>
 
-            <div class="flex items-center w-full my-4">
-              <hr class="w-full text-gray-600" />
-              <p class="px-3 text-gray-600">OR</p>
-              <hr class="w-full text-gray-600" />
+            <div className="flex items-center w-full my-4">
+              <hr className="w-full text-gray-600" />
+              <p className="px-3 text-gray-600">OR</p>
+              <hr className="w-full text-gray-600" />
             </div>
 
-            <div class="flex items-center pt-4 space-x-1">
-              <div class="flex-1 h-px sm:w-16 dark:bg-gray-700"></div>
-              <p class="px-3 text-sm dark:text-gray-400">
+            <div className="flex items-center pt-4 space-x-1">
+              <div className="flex-1 h-px sm:w-16 dark:bg-gray-700"></div>
+              <p className="px-3 text-sm dark:text-gray-400">
                 Login with social accounts
               </p>
-              <div class="flex-1 h-px sm:w-16 dark:bg-gray-700"></div>
+              <div className="flex-1 h-px sm:w-16 dark:bg-gray-700"></div>
             </div>
-            <div class="flex justify-center space-x-4">
-              <button aria-label="Log in with Google" class="p-3 rounded-sm">
+            <div className="flex justify-center space-x-4">
+              <button
+                aria-label="Log in with Google"
+                className="p-3 rounded-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 32 32"
-                  class="w-5 h-5 fill-current">
+                  className="w-5 h-5 fill-current">
                   <path d="M16.318 13.714v5.484h9.078c-0.37 2.354-2.745 6.901-9.078 6.901-5.458 0-9.917-4.521-9.917-10.099s4.458-10.099 9.917-10.099c3.109 0 5.193 1.318 6.38 2.464l4.339-4.182c-2.786-2.599-6.396-4.182-10.719-4.182-8.844 0-16 7.151-16 16s7.156 16 16 16c9.234 0 15.365-6.49 15.365-15.635 0-1.052-0.115-1.854-0.255-2.651z"></path>
                 </svg>
               </button>
-              <button aria-label="Log in with Twitter" class="p-3 rounded-sm">
+              <button
+                aria-label="Log in with Twitter"
+                className="p-3 rounded-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 32 32"
-                  class="w-5 h-5 fill-current">
+                  className="w-5 h-5 fill-current">
                   <path d="M31.937 6.093c-1.177 0.516-2.437 0.871-3.765 1.032 1.355-0.813 2.391-2.099 2.885-3.631-1.271 0.74-2.677 1.276-4.172 1.579-1.192-1.276-2.896-2.079-4.787-2.079-3.625 0-6.563 2.937-6.563 6.557 0 0.521 0.063 1.021 0.172 1.495-5.453-0.255-10.287-2.875-13.52-6.833-0.568 0.964-0.891 2.084-0.891 3.303 0 2.281 1.161 4.281 2.916 5.457-1.073-0.031-2.083-0.328-2.968-0.817v0.079c0 3.181 2.26 5.833 5.26 6.437-0.547 0.145-1.131 0.229-1.724 0.229-0.421 0-0.823-0.041-1.224-0.115 0.844 2.604 3.26 4.5 6.14 4.557-2.239 1.755-5.077 2.801-8.135 2.801-0.521 0-1.041-0.025-1.563-0.088 2.917 1.86 6.36 2.948 10.079 2.948 12.067 0 18.661-9.995 18.661-18.651 0-0.276 0-0.557-0.021-0.839 1.287-0.917 2.401-2.079 3.281-3.396z"></path>
                 </svg>
               </button>
-              <button aria-label="Log in with GitHub" class="p-3 rounded-sm">
+              <button
+                aria-label="Log in with GitHub"
+                className="p-3 rounded-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 32 32"
-                  class="w-5 h-5 fill-current">
+                  className="w-5 h-5 fill-current">
                   <path d="M16 0.396c-8.839 0-16 7.167-16 16 0 7.073 4.584 13.068 10.937 15.183 0.803 0.151 1.093-0.344 1.093-0.772 0-0.38-0.009-1.385-0.015-2.719-4.453 0.964-5.391-2.151-5.391-2.151-0.729-1.844-1.781-2.339-1.781-2.339-1.448-0.989 0.115-0.968 0.115-0.968 1.604 0.109 2.448 1.645 2.448 1.645 1.427 2.448 3.744 1.74 4.661 1.328 0.14-1.031 0.557-1.74 1.011-2.135-3.552-0.401-7.287-1.776-7.287-7.907 0-1.751 0.62-3.177 1.645-4.297-0.177-0.401-0.719-2.031 0.141-4.235 0 0 1.339-0.427 4.4 1.641 1.281-0.355 2.641-0.532 4-0.541 1.36 0.009 2.719 0.187 4 0.541 3.043-2.068 4.381-1.641 4.381-1.641 0.859 2.204 0.317 3.833 0.161 4.235 1.015 1.12 1.635 2.547 1.635 4.297 0 6.145-3.74 7.5-7.296 7.891 0.556 0.479 1.077 1.464 1.077 2.959 0 2.14-0.020 3.864-0.020 4.385 0 0.416 0.28 0.916 1.104 0.755 6.4-2.093 10.979-8.093 10.979-15.156 0-8.833-7.161-16-16-16z"></path>
                 </svg>
               </button>
             </div>
 
-            <p class="text-center text-sm text-gray-500">
+            <p className="text-center text-sm text-gray-500">
               No account?
               <a
-                class="underline hover:text-blue-700 focus:text-blue-700"
+                className="underline hover:text-blue-700 focus:text-blue-700"
                 href="./register.html">
                 {" "}
                 Sign Up

--- a/src/components/Team.jsx
+++ b/src/components/Team.jsx
@@ -8,10 +8,10 @@ import Theodat from "./Images/theodat.png"
 
 const Team = () => {
   return (
-    <section class="mt-16  bg-slate-100 " id="team">
-      <div class="container px-6 py-12 mx-auto">
+    <section className="mt-16  bg-slate-100 " id="team">
+      <div className="container px-6 py-12 mx-auto">
         <Fade>
-          <header class="">
+          <header className="">
             <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <div>
                 <p className="inline-block px-3 py-px mb-4 text-xs font-semibold tracking-wider text-teal-900 uppercase rounded-full bg-teal-accent-400">
@@ -45,7 +45,7 @@ const Team = () => {
                 Our Expert <span className="text-blue-500"> Team </span>
               </h2>
 
-              <p class="max-w-[43rem] text-md mx-auto mt-4 text-gray-600">
+              <p className="max-w-[43rem] text-md mx-auto mt-4 text-gray-600">
                 Our dedicated team of dental professionals is committed to
                 providing you with the best dental care possible.{" "}
                 <span className=" hidden lg:inline">
@@ -58,58 +58,66 @@ const Team = () => {
           </header>
         </Fade>
 
-        <div class="grid gap-8 mt-12  md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4">
-          <div class="w-full max-w-xs text-center">
+        <div className="grid gap-8 mt-12  md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4">
+          <div className="w-full max-w-xs text-center">
             <img
-              class="object-cover object-center w-full h-60 mx-auto rounded-lg"
+              className="object-cover object-center w-full h-60 mx-auto rounded-lg"
               src={Gateme}
               alt="avatar"
             />
 
-            <div class="mt-2">
-              <h3 class="text-md font-bold text-gray-700">GATEME Gaby </h3>
-              <span class="mt-1 font-medium text-gray-600 ">Orthodontist</span>
+            <div className="mt-2">
+              <h3 className="text-md font-bold text-gray-700">GATEME Gaby </h3>
+              <span className="mt-1 font-medium text-gray-600 ">
+                Orthodontist
+              </span>
             </div>
           </div>
 
-          <div class="w-full max-w-xs text-center">
+          <div className="w-full max-w-xs text-center">
             <img
-              class="object-cover object-center w-full h-60 mx-auto rounded-lg"
+              className="object-cover object-center w-full h-60 mx-auto rounded-lg"
               src={Chance}
               alt="avatar"
             />
 
-            <div class="mt-2">
-              <h3 class="text-md font-bold text-gray-700 ">MAHORO Eunice</h3>
-              <span class="mt-1 font-medium text-gray-600 ">Therapist</span>
+            <div className="mt-2">
+              <h3 className="text-md font-bold text-gray-700 ">
+                MAHORO Eunice
+              </h3>
+              <span className="mt-1 font-medium text-gray-600 ">Therapist</span>
             </div>
           </div>
 
-          <div class="w-full max-w-xs text-center">
+          <div className="w-full max-w-xs text-center">
             <img
-              class="object-cover object-center w-full  h-60 mx-auto rounded-lg"
+              className="object-cover object-center w-full  h-60 mx-auto rounded-lg"
               src={Theodat}
               alt="avatar"
             />
 
-            <div class="mt-2">
-              <h3 class="text-md font-bold text-gray-700 ">IBAKA M. Theodat</h3>
-              <span class="mt-1 font-medium text-gray-600 ">
+            <div className="mt-2">
+              <h3 className="text-md font-bold text-gray-700 ">
+                IBAKA M. Theodat
+              </h3>
+              <span className="mt-1 font-medium text-gray-600 ">
                 Dental Surgeon
               </span>
             </div>
           </div>
 
-          <div class="w-full max-w-xs text-center">
+          <div className="w-full max-w-xs text-center">
             <img
-              class="object-cover object-center w-full h-60 mx-auto rounded-lg"
+              className="object-cover object-center w-full h-60 mx-auto rounded-lg"
               src={Arriana}
               alt="Arriana avatar"
             />
 
-            <div class="mt-2">
-              <h3 class="text-md font-bold text-gray-700 ">DUKUNDE Arriana</h3>
-              <span class="mt-1 font-medium text-gray-600 ">Assistant</span>
+            <div className="mt-2">
+              <h3 className="text-md font-bold text-gray-700 ">
+                DUKUNDE Arriana
+              </h3>
+              <span className="mt-1 font-medium text-gray-600 ">Assistant</span>
             </div>
           </div>
         </div>

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -15,7 +15,7 @@ export default function App() {
     <>
       <div className="container mx-auto p-6 mt-1" id="app">
         <Fade>
-          <header class="">
+          <header className="">
             <div className="max-w-xl mb-0 mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <div>
                 <p className="inline-block px-3 py-px mb-4 text-xs font-semibold tracking-wider text-teal-900 uppercase rounded-full bg-teal-accent-400">
@@ -50,7 +50,7 @@ export default function App() {
                 <span className="text-blue-500 relative">Patients</span>
               </h2>
 
-              <p class="max-w-[40rem] text-md mx-auto mt-4 text-gray-500"></p>
+              <p className="max-w-[40rem] text-md mx-auto mt-4 text-gray-500"></p>
             </div>
           </header>
         </Fade>
@@ -84,27 +84,27 @@ export default function App() {
             },
           }}>
           <SwiperSlide className="flex rounded-[4px] my-10 justify-center items-center bg-slate-100">
-            <div class="my-auto carousel-item active relative float-left w-full">
+            <div className="my-auto carousel-item active relative float-left w-full">
               <img
-                class="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
+                className="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
                 src="https://i.ibb.co/XVFPhWP/PSX-20230524-011601.jpg"
                 alt="avatar"
               />
-              <div class="flex my-auto flex-wrap justify-center">
-                <div class="grow-0 shrink-0  basis-auto w-full lg:w-8/12 px-3">
-                  <h5 class=" text-center text-lg font-bold mb-3">
+              <div className="flex my-auto flex-wrap justify-center">
+                <div className="grow-0 shrink-0  basis-auto w-full lg:w-8/12 px-3">
+                  <h5 className=" text-center text-lg font-bold mb-3">
                     UWIMBABAZI Providence
                   </h5>
-                  <p class="text-center font-semibold text-gray-700 mb-4">
+                  <p className="text-center font-semibold text-gray-700 mb-4">
                     Manager - BPR Rwanda
                   </p>
-                  <p class="text-gray-600 mb-12">
+                  <p className="text-gray-600 mb-12">
                     <svg
                       aria-hidden="true"
                       focusable="false"
                       data-prefix="fas"
                       data-icon="quote-left"
-                      class="w-6 pr-2 inline-block"
+                      className="w-6 pr-2 inline-block"
                       role="img"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512">
@@ -118,14 +118,14 @@ export default function App() {
                     care was done with precision and expertise. Thank you DentRw
                     !
                   </p>
-                  <ul class="flex justify-center mb-6">
+                  <ul className="flex justify-center mb-6">
                     <li>
                       <svg
                         aria-hidden="true"
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -140,7 +140,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -155,7 +155,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -170,7 +170,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -185,7 +185,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="far"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -200,27 +200,27 @@ export default function App() {
             </div>
           </SwiperSlide>
           <SwiperSlide className="flex rounded-[4px] my-10 justify-center items-center bg-slate-100">
-            <div class="my-auto carousel-item active relative float-left w-full">
+            <div className="my-auto carousel-item active relative float-left w-full">
               <img
-                class="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
+                className="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
                 src="https://i.ibb.co/8b8NJBN/PSX-20230511-214634.jpg"
                 alt="avatar"
               />
-              <div class="flex flex-wrap justify-center">
-                <div class="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
-                  <h5 class="text-center text-lg font-bold mb-3">
+              <div className="flex flex-wrap justify-center">
+                <div className="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
+                  <h5 className="text-center text-lg font-bold mb-3">
                     RUSHATI Emmanuel
                   </h5>
-                  <p class=" text-center font-semibold text-gray-700 mb-4">
+                  <p className=" text-center font-semibold text-gray-700 mb-4">
                     Driver
                   </p>
-                  <p class="text-gray-500 mb-12">
+                  <p className="text-gray-500 mb-12">
                     <svg
                       aria-hidden="true"
                       focusable="false"
                       data-prefix="fas"
                       data-icon="quote-left"
-                      class="w-6 pr-2 inline-block"
+                      className="w-6 pr-2 inline-block"
                       role="img"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512">
@@ -233,14 +233,14 @@ export default function App() {
                     reliable and professional dental service. Their staff is
                     knowledgeable,caring and always make me feel comfortable.
                   </p>
-                  <ul class="flex justify-center mb-6">
+                  <ul className="flex justify-center mb-6">
                     <li>
                       <svg
                         aria-hidden="true"
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -255,7 +255,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -270,7 +270,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -285,7 +285,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -300,7 +300,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star-half-alt"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 536 512">
@@ -316,27 +316,27 @@ export default function App() {
           </SwiperSlide>
 
           <SwiperSlide className="flex rounded-[4px] my-10 justify-center items-center bg-slate-100">
-            <div class="my-auto carousel-item active relative float-left w-full">
+            <div className="my-auto carousel-item active relative float-left w-full">
               <img
-                class="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
+                className="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
                 src="https://i.ibb.co/NCpZNrf/PSX-20230511-214524.jpg"
                 alt="avatar"
               />
-              <div class="flex  flex-wrap justify-center">
-                <div class="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
-                  <h5 class="text-center text-lg font-bold mb-3">
+              <div className="flex  flex-wrap justify-center">
+                <div className="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
+                  <h5 className="text-center text-lg font-bold mb-3">
                     Chance Divine
                   </h5>
-                  <p class="text-center font-semibold text-gray-700 mb-4">
+                  <p className="text-center font-semibold text-gray-700 mb-4">
                     Engineer
                   </p>
-                  <p class="text-gray-500 mb-12">
+                  <p className="text-gray-500 mb-12">
                     <svg
                       aria-hidden="true"
                       focusable="false"
                       data-prefix="fas"
                       data-icon="quote-left"
-                      class="w-6 pr-2 inline-block"
+                      className="w-6 pr-2 inline-block"
                       role="img"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512">
@@ -349,14 +349,14 @@ export default function App() {
                     service and the quality of their work in such short moment.
                     They are definitey best dental clinic in Kigali!
                   </p>
-                  <ul class="flex justify-center mb-6">
+                  <ul className="flex justify-center mb-6">
                     <li>
                       <svg
                         aria-hidden="true"
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -371,7 +371,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -386,7 +386,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -401,7 +401,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -416,7 +416,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -432,27 +432,27 @@ export default function App() {
           </SwiperSlide>
 
           <SwiperSlide className="flex rounded-[4px] my-10 justify-center items-center bg-slate-100">
-            <div class="my-auto carousel-item active relative float-left w-full">
+            <div className="my-auto carousel-item active relative float-left w-full">
               <img
-                class="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
+                className="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
                 src="https://i.ibb.co/59ysYDf/PSX-20230511-215559.jpg"
                 alt="avatar"
               />
-              <div class="flex my-auto flex-wrap justify-center">
-                <div class="grow-0 shrink-0  basis-auto w-full lg:w-8/12 px-3">
-                  <h5 class=" text-center text-lg font-bold mb-3">
+              <div className="flex my-auto flex-wrap justify-center">
+                <div className="grow-0 shrink-0  basis-auto w-full lg:w-8/12 px-3">
+                  <h5 className=" text-center text-lg font-bold mb-3">
                     TUMUKUNDE Candide
                   </h5>
-                  <p class="text-center font-semibold text-gray-700 mb-4">
+                  <p className="text-center font-semibold text-gray-700 mb-4">
                     CTO - Kasha
                   </p>
-                  <p class="text-gray-500 mb-12">
+                  <p className="text-gray-500 mb-12">
                     <svg
                       aria-hidden="true"
                       focusable="false"
                       data-prefix="fas"
                       data-icon="quote-left"
-                      class="w-6 pr-2 inline-block"
+                      className="w-6 pr-2 inline-block"
                       role="img"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512">
@@ -465,14 +465,14 @@ export default function App() {
                     state-of-the-art. They took great care of me, the dental
                     care was done with precision and expertise.
                   </p>
-                  <ul class="flex justify-center mb-6">
+                  <ul className="flex justify-center mb-6">
                     <li>
                       <svg
                         aria-hidden="true"
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -487,7 +487,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -502,7 +502,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -517,7 +517,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -532,7 +532,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="far"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -547,27 +547,27 @@ export default function App() {
             </div>
           </SwiperSlide>
           <SwiperSlide className="flex rounded-[4px] my-10 justify-center items-center bg-slate-100">
-            <div class="my-auto carousel-item active relative float-left w-full">
+            <div className="my-auto carousel-item active relative float-left w-full">
               <img
-                class="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
+                className="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
                 src={Olvier}
                 alt="avatar"
               />
-              <div class="flex flex-wrap justify-center">
-                <div class="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
-                  <h5 class="text-center text-lg font-bold mb-3">
+              <div className="flex flex-wrap justify-center">
+                <div className="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
+                  <h5 className="text-center text-lg font-bold mb-3">
                     NDIKUMANA M. Olivier
                   </h5>
-                  <p class=" text-center font-semibold text-gray-700 mb-4">
+                  <p className=" text-center font-semibold text-gray-700 mb-4">
                     Businessman
                   </p>
-                  <p class="text-gray-500 mb-12">
+                  <p className="text-gray-500 mb-12">
                     <svg
                       aria-hidden="true"
                       focusable="false"
                       data-prefix="fas"
                       data-icon="quote-left"
-                      class="w-6 pr-2 inline-block"
+                      className="w-6 pr-2 inline-block"
                       role="img"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512">
@@ -580,14 +580,14 @@ export default function App() {
                     reliable and professional dental service. Their staff is
                     knowledgeable,caring and always make me feel comfortable.
                   </p>
-                  <ul class="flex justify-center mb-6">
+                  <ul className="flex justify-center mb-6">
                     <li>
                       <svg
                         aria-hidden="true"
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -602,7 +602,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -617,7 +617,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -632,7 +632,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -647,7 +647,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star-half-alt"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 536 512">
@@ -663,27 +663,27 @@ export default function App() {
           </SwiperSlide>
 
           <SwiperSlide className="flex rounded-[4px] my-10 justify-center items-center bg-slate-100">
-            <div class="my-auto carousel-item active relative float-left w-full">
+            <div className="my-auto carousel-item active relative float-left w-full">
               <img
-                class="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
+                className="rounded-full shadow-lg mb-6 mt-6  w-24 mx-auto"
                 src="https://i.ibb.co/4gv6mm7/PSX-20230511-213331.jpg"
                 alt="avatar"
               />
-              <div class="flex  flex-wrap justify-center">
-                <div class="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
-                  <h5 class="text-center text-lg font-bold mb-3">
+              <div className="flex  flex-wrap justify-center">
+                <div className="grow-0 shrink-0 basis-auto w-full lg:w-8/12 px-3">
+                  <h5 className="text-center text-lg font-bold mb-3">
                     UMWASE Castro Samuel
                   </h5>
-                  <p class="text-center font-semibold text-gray-700 mb-4">
+                  <p className="text-center font-semibold text-gray-700 mb-4">
                     UR Student
                   </p>
-                  <p class="text-gray-500 mb-12">
+                  <p className="text-gray-500 mb-12">
                     <svg
                       aria-hidden="true"
                       focusable="false"
                       data-prefix="fas"
                       data-icon="quote-left"
-                      class="w-6 pr-2 inline-block"
+                      className="w-6 pr-2 inline-block"
                       role="img"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512">
@@ -696,14 +696,14 @@ export default function App() {
                     treatment I received was outstanding. They made me feel like
                     a valued patient, and I highly recommend their services.
                   </p>
-                  <ul class="flex justify-center mb-6">
+                  <ul className="flex justify-center mb-6">
                     <li>
                       <svg
                         aria-hidden="true"
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -718,7 +718,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -733,7 +733,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -748,7 +748,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 576 512">
@@ -763,7 +763,7 @@ export default function App() {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="star-half-alt"
-                        class="w-4 text-yellow-500"
+                        className="w-4 text-yellow-500"
                         role="img"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 536 512">
@@ -778,39 +778,39 @@ export default function App() {
             </div>
           </SwiperSlide>
         </Swiper>
-        <div class="mt-1 flex justify-center items-center gap-4">
+        <div className="mt-1 flex justify-center items-center gap-4">
           <button
             aria-label="Previous slide"
-            class="prev-button rounded-full border border-blue-600 p-2 text-blue-600 hover:bg-blue-500 hover:text-white">
+            className="prev-button rounded-full border border-blue-600 p-2 text-blue-600 hover:bg-blue-500 hover:text-white">
             <svg
-              class="h-5 w-5 -rotate-180 transform"
+              className="h-5 w-5 -rotate-180 transform"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M9 5l7 7-7 7"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
               />
             </svg>
           </button>
 
           <button
             aria-label="Next slide"
-            class="next-button rounded-full border border-blue-600 p-2 text-blue-600 hover:bg-blue-500 hover:text-white">
+            className="next-button rounded-full border border-blue-600 p-2 text-blue-600 hover:bg-blue-500 hover:text-white">
             <svg
-              class="h-5 w-5"
+              className="h-5 w-5"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M9 5l7 7-7 7"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
               />
             </svg>
           </button>


### PR DESCRIPTION
## 📑 Description

Converts HTML-style attributes to their JSX names across 8 components. React 19 logged a `console.error` for each of these on **every page load** (`Invalid DOM property \`class\`. Did you mean \`className\`?` etc.) — the page rendered fine, but the console was full of noise.

- [x] `class="…"` → `className="…"` (239 sites)
- [x] `for="…"` → `htmlFor="…"` (9 label sites in `Contact.jsx` / `Sign.jsx`)
- [x] SVG props: `stroke-linecap` / `stroke-linejoin` / `stroke-width` / `fill-rule` / `clip-rule` → camelCase (`Hero.jsx`, `Sign.jsx`, `Testimonials.jsx`)

`aria-*` and `data-*` attributes are left kebab-case (correct in JSX).

Pure mechanical rename — no logic, no markup structure, no rendered-output change. Some lines re-wrapped by Prettier because `className` is longer than `class`.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

**Verified** in a browser (`bun run dev`): the 7 `Invalid DOM property` console errors are gone (console now only has Vite HMR debug lines), and the page renders identically. `bun run build` / `test` (5 passing) / `lint` / `format` green.

## ℹ Additional Information

- Follow-up from the enhancement roadmap's deferred list (`plans/README.md`). `.oxlintrc.json` still has `react/no-unknown-property` off — could be flipped to `error` now to prevent regressions, but that's a separate change.