### PR TITLE
refactor: drop the unused React default import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,3 @@
-import React from "react"
-
 import "./index.css"
 
 import AnnouncementBar from "./components/AnnouncementBar"

--- a/src/components/AnnouncementBar.jsx
+++ b/src/components/AnnouncementBar.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useTranslation } from "react-i18next"
 
 const AnnouncementBar = () => {

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import emailjs from "@emailjs/browser"
 import { Fade } from "react-awesome-reveal"
 

--- a/src/components/FAQs.jsx
+++ b/src/components/FAQs.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Fade } from "react-awesome-reveal"
 
 const FAQs = () => {

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Fade } from "react-awesome-reveal"
 
 const Features = () => {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import { useState } from "react"
 import axios from "axios"
 import { Fade } from "react-awesome-reveal"
 

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Fade } from "react-awesome-reveal"
 import { Link } from "react-scroll"
 

--- a/src/components/Insurance.jsx
+++ b/src/components/Insurance.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Fade } from "react-awesome-reveal"
 
 import BK from "./Images/insurance/BK.png"

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useTranslation } from "react-i18next"
 
 import { SUPPORTED_LANGUAGES } from "../i18n"

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { Link, animateScroll as scroll } from "react-scroll"
 
 import LanguageSwitcher from "./LanguageSwitcher"

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Fade } from "react-awesome-reveal"
 
 import Service1 from "./Images/beautiful-smile.jpg"

--- a/src/components/Sign.jsx
+++ b/src/components/Sign.jsx
@@ -1,5 +1,3 @@
-import React from "react"
-
 const Sign = () => {
   return (
     <div>

--- a/src/components/Team.jsx
+++ b/src/components/Team.jsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Fade } from "react-awesome-reveal"
 
 import Arriana from "./Images/arriana.png"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 
 import "./index.css"
@@ -8,7 +8,7 @@ import App from "./App"
 
 const root = ReactDOM.createRoot(document.getElementById("root"))
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>
+  </StrictMode>
 )


### PR DESCRIPTION
## 📑 Description

`import React from "react"` is unnecessary since the project moved to Vite's automatic JSX runtime (`@vitejs/plugin-react`). Removes it from all 13 components + `App.jsx`, and switches `index.jsx` to a named `StrictMode` import (the only place that actually used the `React` namespace).

Pure cleanup — no behaviour change. Build already used the automatic runtime; this just deletes the dead import line.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

`bun run build` / `test` (5 passing) / `lint` / `format` green; verified the app still renders via `bun run preview`.

## ℹ Additional Information

Follow-up from the roadmap's deferred list.