### PR TITLE
feat: localize Navbar, Hero, Insurance, Features (en/fr)

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -60,6 +60,29 @@ Example: `contact.form.fullNameLabel`, `hero.headline`.
 `AnnouncementBar.jsx` is the worked example — see it and
 `src/i18n/locales/*/common.json`.
 
+### Strings with inline markup
+
+When a sentence contains an inline element (a coloured `<span>`, a `<br />`, a
+link), use `<Trans>` instead of `t()` so word order can differ per language:
+
+```jsx
+import { Trans } from "react-i18next"
+
+;<Trans
+  i18nKey="insurance:headline"
+  components={{ hl: <span className="text-blue-500" /> }}
+/>
+```
+
+```json
+// en/insurance.json
+"headline": "We work with <hl>Insurance</hl> companies for your coverage"
+// fr/insurance.json
+"headline": "Nous travaillons avec des compagnies d'<hl>assurance</hl> pour votre couverture"
+```
+
+See `Hero.jsx` (uses `<br />` + `<hl>`) and `Insurance.jsx`.
+
 ## Finding untranslated / missing keys
 
 Run the app in dev; i18next logs missing keys to the console. For a stricter
@@ -72,15 +95,16 @@ pass, temporarily set `saveMissing: true` + a `missingKeyHandler` in
   their original language.
 - The brand name "DentRW", external URLs, phone numbers, email addresses.
 
-## Remaining components (rough string counts, suggested order)
+## Coverage
+
+Done: `AnnouncementBar`, `Navbar`, `Hero`, `Insurance`, `Features`
+(namespaces `common`, `navbar`, `hero`, `insurance`, `features`).
+
+Remaining (rough string counts, suggested order):
 
 | Component          | ~strings | Notes                                          |
 | ------------------ | -------: | ---------------------------------------------- |
-| `Navbar.jsx`       |       15 | nav labels + logo alt                          |
-| `Hero.jsx`         |       10 | headline, sub-copy, CTAs                       |
 | `Services.jsx`     |       20 | service names + blurbs                         |
-| `Insurance.jsx`    |        5 | heading + partner labels                       |
-| `Features.jsx`     |       15 |                                                |
 | `Team.jsx`         |       10 | names stay; roles translate                    |
 | `FAQs.jsx`         |       20 | Q + A pairs                                    |
 | `Contact.jsx`      |       30 | form labels, clinic hours, service `<option>`s |

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,180 +1,89 @@
 import { Fade } from "react-awesome-reveal"
+import { useTranslation } from "react-i18next"
+
+const CARD_KEYS = [
+  "virtualConsultation",
+  "onlineBooking",
+  "preventiveCare",
+  "physicalTreatment",
+]
 
 const Features = () => {
+  const { t } = useTranslation("features")
+
   return (
     <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20">
       <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
         <div>
           <p className="inline-block px-3 py-px mb-4 text-xs font-semibold tracking-wider text-teal-900 uppercase rounded-full bg-teal-accent-400">
-            Features
+            {t("eyebrow")}
           </p>
         </div>
         <Fade>
-          <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
-            <span className="relative inline-block">
-              <svg
-                viewBox="0 0 52 24"
-                fill="currentColor"
-                className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
-                <defs>
-                  <pattern
-                    id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
-                    x="0"
-                    y="0"
-                    width=".135"
-                    height=".30">
-                    <circle cx="1" cy="1" r=".7" />
-                  </pattern>
-                </defs>
-                <rect
-                  fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
-                  width="52"
-                  height="24"
-                />
-              </svg>
-              <span className="relative">Your </span>
-            </span>{" "}
-            Comprehensive Dental Care Solution
+          <h2 className="relative max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
+            <svg
+              viewBox="0 0 52 24"
+              fill="currentColor"
+              className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
+              <defs>
+                <pattern
+                  id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
+                  x="0"
+                  y="0"
+                  width=".135"
+                  height=".30">
+                  <circle cx="1" cy="1" r=".7" />
+                </pattern>
+              </defs>
+              <rect
+                fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
+                width="52"
+                height="24"
+              />
+            </svg>
+            <span className="relative">{t("headline")}</span>
           </h2>
         </Fade>
         <Fade>
-          <p className="text-base text-gray-700 md:text-lg">
-            we are dedicated to delivering exceptional dental care with a focus
-            on convenience, prevention, and effective treatments.
-          </p>
+          <p className="text-base text-gray-700 md:text-lg">{t("subhead")}</p>
         </Fade>
       </div>
 
       <div className="grid gap-4 row-gap-5 sm:grid-cols-2 lg:grid-cols-4">
-        <Fade>
-          <div className="flex flex-col justify-between p-5 border rounded shadow-sm">
-            <div>
-              <div className="flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-indigo-50">
-                <svg
-                  className="w-12 h-12 text-deep-purple-accent-400"
-                  stroke="currentColor"
-                  viewBox="0 0 52 52">
-                  <polygon
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                    points="29 13 14 29 25 29 23 39 38 23 27 23"
-                  />
-                </svg>
+        {CARD_KEYS.map((key) => (
+          <Fade key={key}>
+            <div className="flex flex-col justify-between p-5 border rounded shadow-sm">
+              <div>
+                <div className="flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-indigo-50">
+                  <svg
+                    className="w-12 h-12 text-deep-purple-accent-400"
+                    stroke="currentColor"
+                    viewBox="0 0 52 52">
+                    <polygon
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill="none"
+                      points="29 13 14 29 25 29 23 39 38 23 27 23"
+                    />
+                  </svg>
+                </div>
+                <h6 className="mb-2 font-semibold leading-5">
+                  {t(`cards.${key}.title`)}
+                </h6>
+                <p className="mb-3 text-sm text-gray-900">
+                  {t(`cards.${key}.description`)}
+                </p>
               </div>
-              <h6 className="mb-2 font-semibold leading-5">
-                Virtual Consultation{" "}
-              </h6>
-              <p className="mb-3 text-sm text-gray-900">
-                Embracing Technology for your convenience, we understand that
-                your time is valuable, explore treatments where you are.
-              </p>
+              <a
+                href="/"
+                aria-label=""
+                className="inline-flex items-center font-semibold transition-colors duration-200 text-blue-800 hover:text-blue-500">
+                {t("learnMore")}
+              </a>
             </div>
-            <a
-              href="/"
-              aria-label=""
-              className="inline-flex  items-center font-semibold transition-colors duration-200 text-blue-800 hover:text-blue-500">
-              Learn more
-            </a>
-          </div>
-        </Fade>
-        <Fade>
-          <div className="flex flex-col justify-between p-5 border rounded shadow-sm">
-            <div>
-              <div className="flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-indigo-50">
-                <svg
-                  className="w-12 h-12 text-deep-purple-accent-400"
-                  stroke="currentColor"
-                  viewBox="0 0 52 52">
-                  <polygon
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                    points="29 13 14 29 25 29 23 39 38 23 27 23"
-                  />
-                </svg>
-              </div>
-              <h6 className="mb-2 font-semibold leading-5">Online Booking</h6>
-              <p className="mb-3 text-sm text-gray-900">
-                Streamlining your dental experience. We come to believe dental
-                care should be easily accessible everytime and hassle-free.
-              </p>
-            </div>
-            <a
-              href="/"
-              aria-label=""
-              className="inline-flex items-center font-semibold transition-colors duration-200 text-blue-800 hover:text-blue-500">
-              Learn more
-            </a>
-          </div>
-        </Fade>
-        <Fade>
-          <div className="flex flex-col justify-between p-5 border rounded shadow-sm">
-            <div>
-              <div className="flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-indigo-50">
-                <svg
-                  className="w-12 h-12 text-deep-purple-accent-400"
-                  stroke="currentColor"
-                  viewBox="0 0 52 52">
-                  <polygon
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                    points="29 13 14 29 25 29 23 39 38 23 27 23"
-                  />
-                </svg>
-              </div>
-              <h6 className="mb-2 font-semibold leading-5">Preventive Care</h6>
-              <p className="mb-3 text-sm text-gray-900">
-                Foundation for Lifelong Dental Wellness. We prioritize
-                preventive care as cornerstone of mantaining optimal oral
-                health.
-              </p>
-            </div>
-            <a
-              href="/"
-              aria-label=""
-              className="inline-flex items-center font-semibold transition-colors duration-200 text-blue-800 hover:text-blue-500">
-              Learn more
-            </a>
-          </div>
-        </Fade>
-        <Fade>
-          <div className="flex flex-col justify-between p-5 border rounded shadow-sm">
-            <div>
-              <div className="flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-indigo-50">
-                <svg
-                  className="w-12 h-12 text-deep-purple-accent-400"
-                  stroke="currentColor"
-                  viewBox="0 0 52 52">
-                  <polygon
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                    points="29 13 14 29 25 29 23 39 38 23 27 23"
-                  />
-                </svg>
-              </div>
-              <h6 className="mb-2 font-semibold leading-5">
-                Physical Treatment
-              </h6>
-              <p className="mb-3 text-sm text-gray-900">
-                Whether your require cosmetic, restorative, pediatric,
-                orthodontic procedures and more. Our team awaits you.
-              </p>
-            </div>
-            <a
-              href="/"
-              aria-label=""
-              className="inline-flex items-center font-semibold transition-colors duration-200 text-blue-800 hover:text-blue-500">
-              Learn more
-            </a>
-          </div>
-        </Fade>
+          </Fade>
+        ))}
       </div>
     </div>
   )

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,9 +1,12 @@
 import { Fade } from "react-awesome-reveal"
+import { Trans, useTranslation } from "react-i18next"
 import { Link } from "react-scroll"
 
 import homepicture from "./Images/home.png"
 
 const Hero = () => {
+  const { t } = useTranslation("hero")
+
   return (
     <main>
       <div className="" name="home">
@@ -12,18 +15,18 @@ const Hero = () => {
             <div className="">
               <div className="lg:max-w-xl lg:pr-5">
                 <h2 className="md:mt-0 mt-24  mb-6 max-w-lg text-5xl font-light leading-snug tracking-tight text-blue-600 sm:text-8xl">
-                  Meet your <br />
-                  <span className="my-1 inline-block border-b-8 border-blue-600 font-bold text-blue-600">
-                    {" "}
-                    Dentist{" "}
-                  </span>
+                  <Trans
+                    i18nKey="hero:headline"
+                    components={{
+                      br: <br />,
+                      hl: (
+                        <span className="my-1 inline-block border-b-8 border-blue-600 font-bold text-blue-600" />
+                      ),
+                    }}
+                  />
                 </h2>
 
-                <p className="text-base text-gray-700">
-                  Harmonizing Oral health and creating beautiful smiles.
-                  Bringing confidence and wellness to your life through modern
-                  dental care!
-                </p>
+                <p className="text-base text-gray-700">{t("subhead")}</p>
               </div>
               <div className="mt-10 flex flex-col items-center md:flex-row">
                 <Link
@@ -32,7 +35,7 @@ const Hero = () => {
                   duration={500}
                   offset={-100}
                   className="mb-3 inline-flex h-12 w-full items-center justify-center rounded bg-blue-700 px-6 font-medium tracking-wide text-white shadow-md transition duration-200 md:mr-4 md:mb-0 md:w-auto focus:outline-none hover:bg-blue-800">
-                  Book Appointment
+                  {t("bookAppointment")}
                 </Link>
                 <Link
                   to="service"
@@ -40,7 +43,7 @@ const Hero = () => {
                   duration={500}
                   offset={-100}
                   className="underline-offset-2 inline-flex items-center text-xl font-bold text-blue-600 underline transition-colors duration-200 hover:underline">
-                  Get Started
+                  {t("getStarted")}
                 </Link>
               </div>
               <div className="mt-12 flex flex-col space-y-3 divide-gray-300 text-sm text-gray-700 sm:flex-row sm:space-y-0 sm:divide-x">
@@ -58,10 +61,7 @@ const Hero = () => {
                       d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
                     />
                   </svg>
-                  <p>
-                    We are dedicated to providing comprehensive, quality dental
-                    care
-                  </p>
+                  <p>{t("commitment")}</p>
                 </div>
                 <div className="flex max-w-xs space-x-2 px-4">
                   <svg
@@ -77,7 +77,7 @@ const Hero = () => {
                       d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
                     />
                   </svg>
-                  <p> Leading dental clinic in Kigali, Rwanda</p>
+                  <p>{t("location")}</p>
                 </div>
               </div>
             </div>
@@ -122,7 +122,7 @@ const Hero = () => {
                   <img
                     className="-mb-20"
                     src={homepicture}
-                    alt="hero portrait"
+                    alt={t("imageAlt")}
                   />
                 </Fade>
               </div>

--- a/src/components/Insurance.jsx
+++ b/src/components/Insurance.jsx
@@ -1,4 +1,5 @@
 import { Fade } from "react-awesome-reveal"
+import { Trans, useTranslation } from "react-i18next"
 
 import BK from "./Images/insurance/BK.png"
 import BRITAM from "./Images/insurance/britam.png"
@@ -10,6 +11,8 @@ import SANLAM from "./Images/insurance/sanlam.png"
 import SORAS from "./Images/insurance/Soras.png"
 
 const Insurance = () => {
+  const { t } = useTranslation("insurance")
+
   return (
     <section className="mt-16 " id="insurance">
       <header className="">
@@ -17,35 +20,36 @@ const Insurance = () => {
           <div className="max-w-xl mb-10 mx-4 md:mx-auto  sm:text-center lg:max-w-2xl md:mb-12">
             <div>
               <p className="inline-block px-3 py-px mb-4 text-xs font-semibold tracking-wider text-teal-900 uppercase rounded-full bg-teal-accent-400">
-                insurance
+                {t("eyebrow")}
               </p>
             </div>
-            <h2 className="max-w-md mb-6 font-sans text-2xl md:text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
-              <span className="relative inline-block">
-                <svg
-                  viewBox="0 0 52 24"
-                  fill="currentColor"
-                  className="absolute top-0 left-2 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
-                  <defs>
-                    <pattern
-                      id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
-                      x="0"
-                      y="0"
-                      width=".135"
-                      height=".30">
-                      <circle cx="1" cy="1" r=".7" />
-                    </pattern>
-                  </defs>
-                  <rect
-                    fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
-                    width="52"
-                    height="24"
-                  />
-                </svg>
-                <span className="relative">We </span>
-              </span>{" "}
-              work with <span className="text-blue-500">Insurance</span>{" "}
-              companies for your coverage
+            <h2 className="relative max-w-md mb-6 font-sans text-2xl md:text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
+              <svg
+                viewBox="0 0 52 24"
+                fill="currentColor"
+                className="absolute top-0 left-2 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
+                <defs>
+                  <pattern
+                    id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
+                    x="0"
+                    y="0"
+                    width=".135"
+                    height=".30">
+                    <circle cx="1" cy="1" r=".7" />
+                  </pattern>
+                </defs>
+                <rect
+                  fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
+                  width="52"
+                  height="24"
+                />
+              </svg>
+              <span className="relative">
+                <Trans
+                  i18nKey="insurance:headline"
+                  components={{ hl: <span className="text-blue-500" /> }}
+                />
+              </span>
             </h2>
 
             <p className="max-w-[40rem] text-md mx-auto mt-4 text-gray-500"></p>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Link, animateScroll as scroll } from "react-scroll"
 
 import LanguageSwitcher from "./LanguageSwitcher"
 
 const Navbar = () => {
+  const { t } = useTranslation("navbar")
   const [showNavbar, setShowNavbar] = useState(false)
   const [showMenu, setShowMenu] = useState(false)
 
@@ -21,31 +23,11 @@ const Navbar = () => {
   }, [])
 
   const links = [
-    {
-      id: 1,
-      link: "home",
-      label: "Home",
-    },
-    {
-      id: 2,
-      link: "service",
-      label: "Services",
-    },
-    {
-      id: 3,
-      link: "insurance",
-      label: "Insurance",
-    },
-    {
-      id: 4,
-      link: "team",
-      label: "Team",
-    },
-    {
-      id: 5,
-      link: "contact",
-      label: "Book Now",
-    },
+    { id: 1, link: "home", labelKey: "home" },
+    { id: 2, link: "service", labelKey: "services" },
+    { id: 3, link: "insurance", labelKey: "insurance" },
+    { id: 4, link: "team", labelKey: "team" },
+    { id: 5, link: "contact", labelKey: "bookNow" },
   ]
 
   const scrollToTop = () => {
@@ -90,7 +72,7 @@ const Navbar = () => {
 
       <nav className="hidden md:block">
         <ul className="flex items-center space-x-6">
-          {links.map(({ id, link, label }) => (
+          {links.map(({ id, link, labelKey }) => (
             <li key={id}>
               <Link
                 to={link}
@@ -99,7 +81,7 @@ const Navbar = () => {
                 }`}
                 smooth={true}
                 duration={500}>
-                {label}
+                {t(labelKey)}
               </Link>
             </li>
           ))}
@@ -130,7 +112,7 @@ const Navbar = () => {
         </button>
         {showMenu && (
           <ul className="absolute top-14 right-0 z-50 w-48 py-2 bg-white border border-gray-300 rounded shadow-md">
-            {links.map(({ id, link, label }) => (
+            {links.map(({ id, link, labelKey }) => (
               <li key={id}>
                 <Link
                   to={link}
@@ -138,7 +120,7 @@ const Navbar = () => {
                   smooth={true}
                   duration={500}
                   onClick={toggleMenu}>
-                  {label}
+                  {t(labelKey)}
                 </Link>
               </li>
             ))}

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -3,7 +3,15 @@ import LanguageDetector from "i18next-browser-languagedetector"
 import { initReactI18next } from "react-i18next"
 
 import enCommon from "./locales/en/common.json"
+import enFeatures from "./locales/en/features.json"
+import enHero from "./locales/en/hero.json"
+import enInsurance from "./locales/en/insurance.json"
+import enNavbar from "./locales/en/navbar.json"
 import frCommon from "./locales/fr/common.json"
+import frFeatures from "./locales/fr/features.json"
+import frHero from "./locales/fr/hero.json"
+import frInsurance from "./locales/fr/insurance.json"
+import frNavbar from "./locales/fr/navbar.json"
 
 export const SUPPORTED_LANGUAGES = ["en", "fr"]
 
@@ -12,8 +20,20 @@ i18n
   .use(initReactI18next)
   .init({
     resources: {
-      en: { common: enCommon },
-      fr: { common: frCommon },
+      en: {
+        common: enCommon,
+        navbar: enNavbar,
+        hero: enHero,
+        insurance: enInsurance,
+        features: enFeatures,
+      },
+      fr: {
+        common: frCommon,
+        navbar: frNavbar,
+        hero: frHero,
+        insurance: frInsurance,
+        features: frFeatures,
+      },
     },
     fallbackLng: "en",
     supportedLngs: SUPPORTED_LANGUAGES,

--- a/src/i18n/locales/en/features.json
+++ b/src/i18n/locales/en/features.json
@@ -1,0 +1,24 @@
+{
+  "eyebrow": "Features",
+  "headline": "Your Comprehensive Dental Care Solution",
+  "subhead": "we are dedicated to delivering exceptional dental care with a focus on convenience, prevention, and effective treatments.",
+  "learnMore": "Learn more",
+  "cards": {
+    "virtualConsultation": {
+      "title": "Virtual Consultation",
+      "description": "Embracing Technology for your convenience, we understand that your time is valuable, explore treatments where you are."
+    },
+    "onlineBooking": {
+      "title": "Online Booking",
+      "description": "Streamlining your dental experience. We come to believe dental care should be easily accessible everytime and hassle-free."
+    },
+    "preventiveCare": {
+      "title": "Preventive Care",
+      "description": "Foundation for Lifelong Dental Wellness. We prioritize preventive care as cornerstone of mantaining optimal oral health."
+    },
+    "physicalTreatment": {
+      "title": "Physical Treatment",
+      "description": "Whether your require cosmetic, restorative, pediatric, orthodontic procedures and more. Our team awaits you."
+    }
+  }
+}

--- a/src/i18n/locales/en/hero.json
+++ b/src/i18n/locales/en/hero.json
@@ -1,0 +1,9 @@
+{
+  "headline": "Meet your<br /><hl>Dentist</hl>",
+  "subhead": "Harmonizing Oral health and creating beautiful smiles. Bringing confidence and wellness to your life through modern dental care!",
+  "bookAppointment": "Book Appointment",
+  "getStarted": "Get Started",
+  "commitment": "We are dedicated to providing comprehensive, quality dental care",
+  "location": "Leading dental clinic in Kigali, Rwanda",
+  "imageAlt": "Smiling dental patient"
+}

--- a/src/i18n/locales/en/insurance.json
+++ b/src/i18n/locales/en/insurance.json
@@ -1,0 +1,4 @@
+{
+  "eyebrow": "insurance",
+  "headline": "We work with <hl>Insurance</hl> companies for your coverage"
+}

--- a/src/i18n/locales/en/navbar.json
+++ b/src/i18n/locales/en/navbar.json
@@ -1,0 +1,7 @@
+{
+  "home": "Home",
+  "services": "Services",
+  "insurance": "Insurance",
+  "team": "Team",
+  "bookNow": "Book Now"
+}

--- a/src/i18n/locales/fr/features.json
+++ b/src/i18n/locales/fr/features.json
@@ -1,0 +1,24 @@
+{
+  "eyebrow": "Fonctionnalités",
+  "headline": "Votre solution complète de soins dentaires",
+  "subhead": "Nous nous engageons à offrir des soins dentaires exceptionnels, axés sur la commodité, la prévention et des traitements efficaces.",
+  "learnMore": "En savoir plus",
+  "cards": {
+    "virtualConsultation": {
+      "title": "Consultation virtuelle",
+      "description": "La technologie au service de votre confort : nous savons que votre temps est précieux, explorez les traitements où que vous soyez."
+    },
+    "onlineBooking": {
+      "title": "Réservation en ligne",
+      "description": "Simplifier votre parcours dentaire. Nous pensons que les soins dentaires doivent être facilement accessibles et sans tracas."
+    },
+    "preventiveCare": {
+      "title": "Soins préventifs",
+      "description": "Le fondement d'une santé dentaire durable. Nous plaçons les soins préventifs au cœur d'une santé bucco-dentaire optimale."
+    },
+    "physicalTreatment": {
+      "title": "Traitement en cabinet",
+      "description": "Que vous ayez besoin de soins esthétiques, restaurateurs, pédiatriques ou orthodontiques, notre équipe vous attend."
+    }
+  }
+}

--- a/src/i18n/locales/fr/hero.json
+++ b/src/i18n/locales/fr/hero.json
@@ -1,0 +1,9 @@
+{
+  "headline": "Rencontrez votre<br /><hl>dentiste</hl>",
+  "subhead": "Harmoniser la santé bucco-dentaire et créer de beaux sourires. Apporter confiance et bien-être à votre vie grâce à des soins dentaires modernes !",
+  "bookAppointment": "Prendre rendez-vous",
+  "getStarted": "Commencer",
+  "commitment": "Nous nous engageons à offrir des soins dentaires complets et de qualité",
+  "location": "Clinique dentaire de référence à Kigali, Rwanda",
+  "imageAlt": "Patiente dentaire souriante"
+}

--- a/src/i18n/locales/fr/insurance.json
+++ b/src/i18n/locales/fr/insurance.json
@@ -1,0 +1,4 @@
+{
+  "eyebrow": "assurance",
+  "headline": "Nous travaillons avec des compagnies d'<hl>assurance</hl> pour votre couverture"
+}

--- a/src/i18n/locales/fr/navbar.json
+++ b/src/i18n/locales/fr/navbar.json
@@ -1,0 +1,7 @@
+{
+  "home": "Accueil",
+  "services": "Services",
+  "insurance": "Assurance",
+  "team": "Équipe",
+  "bookNow": "Rendez-vous"
+}


### PR DESCRIPTION
## 📑 Description

i18n sweep, group 1 of 3. Converts the top-of-page sections to `react-i18next` and adds English + **French** translations.

- [x] `Navbar` — nav labels (`navbar` namespace)
- [x] `Hero` — headline, sub-copy, CTAs, feature blurbs, image alt (`hero` namespace)
- [x] `Insurance` — eyebrow + headline (`insurance` namespace)
- [x] `Features` — eyebrow, headline, sub-copy, 4 feature cards, "Learn more" (`features` namespace); the 4 identical cards are now a `.map` over `CARD_KEYS`
- [x] 4 new namespaces registered in `src/i18n/index.js`
- [x] Headlines with an inline highlight / `<br />` use `<Trans>` so French word order works — pattern documented in `docs/i18n.md`
- [x] `docs/i18n.md` coverage list updated

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

**Verified** in the browser (`bun run dev`) in both languages: EN renders identically to before; FR shows translated nav ("Accueil / Assurance / Équipe / Rendez-vous"), hero ("Rencontrez votre **dentiste**" — highlight + line break preserved), insurance ("compagnies d'**assurance**"), and features. `<html lang>` switches, no missing-key console warnings. Build / test (5) / lint / format green.

## ℹ Additional Information

- **English is carried over verbatim**, including a few pre-existing typos (`everytime`, `mantaining`, `your require`, lowercase sentence starts). French is clean. A separate English copy pass would be worthwhile.
- The decorative dot-pattern SVG behind each headline now sits in a `relative` `<h2>` wrapper instead of an `inline-block` span around the first word — visually the same, but lets the headline wrap normally in either language.
- Group 2 (Services / Team / FAQs) and group 3 (Contact / Footer / Testimonials chrome) to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added French translations for navigation, hero, insurance, and features content.
  * Localized the navigation menu, hero section, insurance section, and feature cards.
  * Added support for translated headlines containing inline formatting and highlighted text.

* **Documentation**
  * Updated internationalization guidance with inline markup examples and current translation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->