### PR TITLE
feat: localize Services, Team, FAQs (en/fr)

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -26,21 +26,9 @@ src/i18n/
 ## Namespaces
 
 One JSON file per feature area under `src/i18n/locales/<lng>/<namespace>.json`.
-Only `common` exists today. When a component needs its own namespace (e.g.
-`contact`, `services`), add `contact.json` under **both** `en/` and `fr/`, and
-register it in `src/i18n/index.js`:
-
-```js
-import enContact from "./locales/en/contact.json"
-import frContact from "./locales/fr/contact.json"
-// ...
-resources: {
-  en: { common: enCommon, contact: enContact },
-  fr: { common: frCommon, contact: frContact },
-}
-```
-
-Then `useTranslation("contact")` in the component.
+`src/i18n/index.js` auto-loads them with `import.meta.glob` — to add a namespace
+you just create `<name>.json` under **both** `en/` and `fr/`, then call
+`useTranslation("<name>")` in the component. No edit to `index.js`.
 
 ## Key naming
 
@@ -97,16 +85,16 @@ pass, temporarily set `saveMissing: true` + a `missingKeyHandler` in
 
 ## Coverage
 
-Done: `AnnouncementBar`, `Navbar`, `Hero`, `Insurance`, `Features`
-(namespaces `common`, `navbar`, `hero`, `insurance`, `features`).
+Done: `AnnouncementBar`, `Navbar`, `Hero`, `Insurance`, `Features`, `Services`,
+`Team`, `FAQs`.
+
+Namespaces are auto-loaded — `src/i18n/index.js` globs
+`./locales/*/*.json`, so a new namespace is just two JSON files, no code edit.
 
 Remaining (rough string counts, suggested order):
 
 | Component          | ~strings | Notes                                          |
 | ------------------ | -------: | ---------------------------------------------- |
-| `Services.jsx`     |       20 | service names + blurbs                         |
-| `Team.jsx`         |       10 | names stay; roles translate                    |
-| `FAQs.jsx`         |       20 | Q + A pairs                                    |
 | `Contact.jsx`      |       30 | form labels, clinic hours, service `<option>`s |
 | `Footer.jsx`       |       40 | newsletter copy, link columns                  |
 | `Testimonials.jsx` |       10 | UI chrome only — leave quotes                  |

--- a/src/components/FAQs.jsx
+++ b/src/components/FAQs.jsx
@@ -1,81 +1,35 @@
 import { Fade } from "react-awesome-reveal"
+import { useTranslation } from "react-i18next"
 
 const FAQs = () => {
+  const { t } = useTranslation("faqs")
+  const items = t("items", { returnObjects: true })
+
   return (
     <section className="bg-white pb-7 text-slate-900">
       <div className="container  flex flex-col justify-center p-3 mx-auto md:p-8">
         <Fade>
           <h2 className="mb-10 mt-10 text-3xl font-bold leading-none text-center sm:mx-4">
-            {" "}
-            Frequently Asked Questions
+            {t("title")}
           </h2>
         </Fade>
         <div className="flex flex-col divide-y divide-gray-300 sm:mx-12 lg:px-12 xl:px-32 mb-10">
-          <Fade>
-            <details>
-              <summary className="py-2 outline-none cursor-pointer focus:font-semibold">
-                {" "}
-                What Services does DentRw offer?
-              </summary>
-
-              <div className="px-4 pb-4">
-                <p>
-                  {" "}
-                  DentRw offers a wide range of dental services, including
-                  preventative care, virtual consultation, cleanings, fillings,
-                  root canals, extractions and more. Our Experienced team is
-                  dedicated to providing exceptional oral health care to our
-                  patients
-                </p>
-              </div>
-            </details>
-          </Fade>
-          <Fade>
-            <details>
-              <summary className="py-2 outline-none cursor-pointer focus:font-semibold">
-                {" "}
-                What are the effects of taditional habit known as Gukura
-                Ibyinyo/Tooth bud extraction?{" "}
-              </summary>
-              <div>
-                <p className="px-4 pb-4">
-                  It's important to note that tooth bud extraction can have
-                  serious and detrimental effects on oral health. The tooth buds
-                  are the immature teeth that are still developing beneath the
-                  gums in children. Removing these tooth buds interferes with
-                  the natural eruption and alignment of permanent teeth, leading
-                  to various dental issues.
-                </p>
-                <p className="px-4 pb-4">
-                  Some potential effects of tooth bud extraction include:
-                  Misalignment of Teeth, Impacted Teeth, Bite Problems
-                  ,Psychological Impact. It's essential to prioritize
-                  evidence-based dental care practices.
-                </p>
-              </div>
-            </details>
-          </Fade>
-          <Fade>
-            <details>
-              <summary className="py-2 outline-none cursor-pointer focus:font-semibold">
-                {" "}
-                How do I schedule an appointment at DentRw ?{" "}
-              </summary>
-              <div>
-                <p className="px-4 pb-4">
-                  {" "}
-                  To schedule appointment at DentRw simpy fill below form and
-                  submit.
-                </p>
-                <p className="px-4 pb-4">
-                  {" "}
-                  Besides our online booking system, you can also give us a
-                  call. We offer flexible scheduling options to ensure that you
-                  can receive the care you need at a time that works for you.
-                </p>
-              </div>
-            </details>
-          </Fade>
+          {items.map((item, i) => (
+            <Fade key={i}>
+              <details>
+                <summary className="py-2 outline-none cursor-pointer focus:font-semibold">
+                  {item.question}
+                </summary>
+                <div>
+                  {item.answers.map((paragraph, j) => (
+                    <p key={j} className="px-4 pb-4">
+                      {paragraph}
+                    </p>
+                  ))}
+                </div>
+              </details>
+            </Fade>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,4 +1,5 @@
 import { Fade } from "react-awesome-reveal"
+import { Trans, useTranslation } from "react-i18next"
 
 import Service1 from "./Images/beautiful-smile.jpg"
 import Ortho from "./Images/braces.jpeg"
@@ -9,7 +10,20 @@ import Toothache from "./Images/inflamation.jpg"
 import RootCanal from "./Images/rootcanal.jpeg"
 import Xray from "./Images/xray.jpeg"
 
+const SERVICE_ITEMS = [
+  { key: "cleaning", image: Service1 },
+  { key: "xray", image: Xray },
+  { key: "orthodontic", image: Ortho },
+  { key: "bridge", image: Bridge },
+  { key: "toothache", image: Toothache },
+  { key: "extraction", image: Extraction },
+  { key: "rootCanal", image: RootCanal },
+  { key: "consultation", image: Consultation },
+]
+
 const Services = () => {
+  const { t } = useTranslation("services")
+
   return (
     <section className="px-5 " id="service">
       <div className=" ">
@@ -18,135 +32,58 @@ const Services = () => {
             <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <div>
                 <p className="inline-block px-3 py-px mb-4 text-xs font-semibold tracking-wider text-teal-900 uppercase rounded-full bg-teal-accent-400">
-                  Services
+                  {t("eyebrow")}
                 </p>
               </div>
-              <h2 className="max-w-[40rem] mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
-                <span className="relative inline-block">
-                  <svg
-                    viewBox="0 0 52 24"
-                    fill="currentColor"
-                    className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
-                    <defs>
-                      <pattern
-                        id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
-                        x="0"
-                        y="0"
-                        width=".135"
-                        height=".30">
-                        <circle cx="1" cy="1" r=".7" />
-                      </pattern>
-                    </defs>
-                    <rect
-                      fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
-                      width="52"
-                      height="24"
-                    />
-                  </svg>
-                  <span className="relative"> The </span>
-                </span>{" "}
-                Suite of dental <span className="text-blue-500">Services</span>{" "}
-                we offers
+              <h2 className="relative max-w-[40rem] mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
+                <svg
+                  viewBox="0 0 52 24"
+                  fill="currentColor"
+                  className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
+                  <defs>
+                    <pattern
+                      id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
+                      x="0"
+                      y="0"
+                      width=".135"
+                      height=".30">
+                      <circle cx="1" cy="1" r=".7" />
+                    </pattern>
+                  </defs>
+                  <rect
+                    fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
+                    width="52"
+                    height="24"
+                  />
+                </svg>
+                <span className="relative">
+                  <Trans
+                    i18nKey="services:headline"
+                    components={{ hl: <span className="text-blue-500" /> }}
+                  />
+                </span>
               </h2>
 
               <p className="max-w-[40rem] text-md mx-auto mt-4 text-gray-500">
-                DentRw provide a comprehensive suite of dental services
-                including General, Cosmetic, Restorative, Pediatric and
-                Emergency Dentistry.
+                {t("subhead")}
               </p>
             </div>
           </Fade>
         </header>
 
         <ul className="grid gap-4 h-30 mt-6 sm:grid-cols-2   lg:grid-cols-4 ">
-          <Fade>
-            <li className="bg-slate-200 ">
-              <img src={Service1} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Cleaning & Teeth whitening
-                </h3>
-              </div>
-            </li>
-          </Fade>
-
-          <Fade>
-            <li className="bg-slate-200 ">
-              <img src={Xray} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 ">X-ray</h3>
-              </div>
-            </li>
-          </Fade>
-
-          <Fade>
-            <li className="bg-slate-200">
-              <img src={Ortho} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Orthodontic Treatment
-                </h3>
-              </div>
-            </li>
-          </Fade>
-          <Fade>
-            <li className="bg-slate-200 ">
-              <img src={Bridge} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Dental Bridge
-                </h3>
-              </div>
-            </li>
-          </Fade>
-          <Fade>
-            <li className="bg-slate-200">
-              <img src={Toothache} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Toothache relief
-                </h3>
-              </div>
-            </li>
-          </Fade>
-          <Fade>
-            <li className="bg-slate-200">
-              <img src={Extraction} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Extraction
-                </h3>
-              </div>
-            </li>
-          </Fade>
-          <Fade>
-            <li className="bg-slate-200">
-              <img src={RootCanal} alt="" className="" />
-
-              <div className="relative py-2">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Root Canal Treatment
-                </h3>
-              </div>
-            </li>
-          </Fade>
-          <Fade>
-            <li className="bg-slate-200 rounded-[4px]">
-              <img src={Consultation} alt="" className=" " />
-
-              <div className="relative py-2 ">
-                <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
-                  Check-ups and Consultation
-                </h3>
-              </div>
-            </li>
-          </Fade>
+          {SERVICE_ITEMS.map(({ key, image }) => (
+            <Fade key={key}>
+              <li className="bg-slate-200">
+                <img src={image} alt="" />
+                <div className="relative py-2">
+                  <h3 className="text-m text-center text-gray-700 group-hover:underline group-hover:underline-offset-4">
+                    {t(`items.${key}`)}
+                  </h3>
+                </div>
+              </li>
+            </Fade>
+          ))}
         </ul>
       </div>
     </section>

--- a/src/components/Team.jsx
+++ b/src/components/Team.jsx
@@ -1,11 +1,21 @@
 import { Fade } from "react-awesome-reveal"
+import { Trans, useTranslation } from "react-i18next"
 
 import Arriana from "./Images/arriana.png"
 import Chance from "./Images/chance.png"
 import Gateme from "./Images/gateme.png"
 import Theodat from "./Images/theodat.png"
 
+const TEAM = [
+  { name: "GATEME Gaby", image: Gateme, roleKey: "orthodontist" },
+  { name: "MAHORO Eunice", image: Chance, roleKey: "therapist" },
+  { name: "IBAKA M. Theodat", image: Theodat, roleKey: "dentalSurgeon" },
+  { name: "DUKUNDE Arriana", image: Arriana, roleKey: "assistant" },
+]
+
 const Team = () => {
+  const { t } = useTranslation("team")
+
   return (
     <section className="mt-16  bg-slate-100 " id="team">
       <div className="container px-6 py-12 mx-auto">
@@ -14,111 +24,63 @@ const Team = () => {
             <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <div>
                 <p className="inline-block px-3 py-px mb-4 text-xs font-semibold tracking-wider text-teal-900 uppercase rounded-full bg-teal-accent-400">
-                  Team
+                  {t("eyebrow")}
                 </p>
               </div>
-              <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
-                <span className="relative inline-block">
-                  <svg
-                    viewBox="0 0 52 24"
-                    fill="currentColor"
-                    className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
-                    <defs>
-                      <pattern
-                        id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
-                        x="0"
-                        y="0"
-                        width=".135"
-                        height=".30">
-                        <circle cx="1" cy="1" r=".7" />
-                      </pattern>
-                    </defs>
-                    <rect
-                      fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
-                      width="52"
-                      height="24"
-                    />
-                  </svg>
-                  <span className="relative"> Meet </span>
-                </span>{" "}
-                Our Expert <span className="text-blue-500"> Team </span>
+              <h2 className="relative max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 sm:text-4xl md:mx-auto">
+                <svg
+                  viewBox="0 0 52 24"
+                  fill="currentColor"
+                  className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 text-blue-gray-100 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block">
+                  <defs>
+                    <pattern
+                      id="18302e52-9e2a-4c8e-9550-0cbb21b38e55"
+                      x="0"
+                      y="0"
+                      width=".135"
+                      height=".30">
+                      <circle cx="1" cy="1" r=".7" />
+                    </pattern>
+                  </defs>
+                  <rect
+                    fill="url(#18302e52-9e2a-4c8e-9550-0cbb21b38e55)"
+                    width="52"
+                    height="24"
+                  />
+                </svg>
+                <span className="relative">
+                  <Trans
+                    i18nKey="team:headline"
+                    components={{ hl: <span className="text-blue-500" /> }}
+                  />
+                </span>
               </h2>
 
               <p className="max-w-[43rem] text-md mx-auto mt-4 text-gray-600">
-                Our dedicated team of dental professionals is committed to
-                providing you with the best dental care possible.{" "}
-                <span className=" hidden lg:inline">
-                  Each member of our team is highly skilled and experienced in
-                  their respective areas of expertise, ensuring that you receive
-                  personalized and high-quality treatment.
-                </span>
+                {t("subhead")}{" "}
+                <span className=" hidden lg:inline">{t("subheadExtra")}</span>
               </p>
             </div>
           </header>
         </Fade>
 
         <div className="grid gap-8 mt-12  md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4">
-          <div className="w-full max-w-xs text-center">
-            <img
-              className="object-cover object-center w-full h-60 mx-auto rounded-lg"
-              src={Gateme}
-              alt="avatar"
-            />
+          {TEAM.map(({ name, image, roleKey }) => (
+            <div key={name} className="w-full max-w-xs text-center">
+              <img
+                className="object-cover object-center w-full h-60 mx-auto rounded-lg"
+                src={image}
+                alt={name}
+              />
 
-            <div className="mt-2">
-              <h3 className="text-md font-bold text-gray-700">GATEME Gaby </h3>
-              <span className="mt-1 font-medium text-gray-600 ">
-                Orthodontist
-              </span>
+              <div className="mt-2">
+                <h3 className="text-md font-bold text-gray-700">{name}</h3>
+                <span className="mt-1 font-medium text-gray-600 ">
+                  {t(`roles.${roleKey}`)}
+                </span>
+              </div>
             </div>
-          </div>
-
-          <div className="w-full max-w-xs text-center">
-            <img
-              className="object-cover object-center w-full h-60 mx-auto rounded-lg"
-              src={Chance}
-              alt="avatar"
-            />
-
-            <div className="mt-2">
-              <h3 className="text-md font-bold text-gray-700 ">
-                MAHORO Eunice
-              </h3>
-              <span className="mt-1 font-medium text-gray-600 ">Therapist</span>
-            </div>
-          </div>
-
-          <div className="w-full max-w-xs text-center">
-            <img
-              className="object-cover object-center w-full  h-60 mx-auto rounded-lg"
-              src={Theodat}
-              alt="avatar"
-            />
-
-            <div className="mt-2">
-              <h3 className="text-md font-bold text-gray-700 ">
-                IBAKA M. Theodat
-              </h3>
-              <span className="mt-1 font-medium text-gray-600 ">
-                Dental Surgeon
-              </span>
-            </div>
-          </div>
-
-          <div className="w-full max-w-xs text-center">
-            <img
-              className="object-cover object-center w-full h-60 mx-auto rounded-lg"
-              src={Arriana}
-              alt="Arriana avatar"
-            />
-
-            <div className="mt-2">
-              <h3 className="text-md font-bold text-gray-700 ">
-                DUKUNDE Arriana
-              </h3>
-              <span className="mt-1 font-medium text-gray-600 ">Assistant</span>
-            </div>
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -2,39 +2,23 @@ import i18n from "i18next"
 import LanguageDetector from "i18next-browser-languagedetector"
 import { initReactI18next } from "react-i18next"
 
-import enCommon from "./locales/en/common.json"
-import enFeatures from "./locales/en/features.json"
-import enHero from "./locales/en/hero.json"
-import enInsurance from "./locales/en/insurance.json"
-import enNavbar from "./locales/en/navbar.json"
-import frCommon from "./locales/fr/common.json"
-import frFeatures from "./locales/fr/features.json"
-import frHero from "./locales/fr/hero.json"
-import frInsurance from "./locales/fr/insurance.json"
-import frNavbar from "./locales/fr/navbar.json"
-
 export const SUPPORTED_LANGUAGES = ["en", "fr"]
+
+// Auto-load every locale namespace: src/i18n/locales/<lng>/<namespace>.json
+// Adding a namespace is just adding the two JSON files — no edit here.
+const modules = import.meta.glob("./locales/*/*.json", { eager: true })
+const resources = {}
+for (const [path, mod] of Object.entries(modules)) {
+  const [, lng, ns] = path.match(/\/locales\/([^/]+)\/([^/]+)\.json$/)
+  resources[lng] ??= {}
+  resources[lng][ns] = mod.default
+}
 
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    resources: {
-      en: {
-        common: enCommon,
-        navbar: enNavbar,
-        hero: enHero,
-        insurance: enInsurance,
-        features: enFeatures,
-      },
-      fr: {
-        common: frCommon,
-        navbar: frNavbar,
-        hero: frHero,
-        insurance: frInsurance,
-        features: frFeatures,
-      },
-    },
+    resources,
     fallbackLng: "en",
     supportedLngs: SUPPORTED_LANGUAGES,
     // Treat region variants (e.g. "en-US", "fr-FR") as their base language

--- a/src/i18n/locales/en/faqs.json
+++ b/src/i18n/locales/en/faqs.json
@@ -1,0 +1,25 @@
+{
+  "title": "Frequently Asked Questions",
+  "items": [
+    {
+      "question": "What Services does DentRw offer?",
+      "answers": [
+        "DentRw offers a wide range of dental services, including preventative care, virtual consultation, cleanings, fillings, root canals, extractions and more. Our Experienced team is dedicated to providing exceptional oral health care to our patients"
+      ]
+    },
+    {
+      "question": "What are the effects of taditional habit known as Gukura Ibyinyo/Tooth bud extraction?",
+      "answers": [
+        "It's important to note that tooth bud extraction can have serious and detrimental effects on oral health. The tooth buds are the immature teeth that are still developing beneath the gums in children. Removing these tooth buds interferes with the natural eruption and alignment of permanent teeth, leading to various dental issues.",
+        "Some potential effects of tooth bud extraction include: Misalignment of Teeth, Impacted Teeth, Bite Problems ,Psychological Impact. It's essential to prioritize evidence-based dental care practices."
+      ]
+    },
+    {
+      "question": "How do I schedule an appointment at DentRw ?",
+      "answers": [
+        "To schedule appointment at DentRw simpy fill below form and submit.",
+        "Besides our online booking system, you can also give us a call. We offer flexible scheduling options to ensure that you can receive the care you need at a time that works for you."
+      ]
+    }
+  ]
+}

--- a/src/i18n/locales/en/services.json
+++ b/src/i18n/locales/en/services.json
@@ -1,0 +1,15 @@
+{
+  "eyebrow": "Services",
+  "headline": "The Suite of dental <hl>Services</hl> we offers",
+  "subhead": "DentRw provide a comprehensive suite of dental services including General, Cosmetic, Restorative, Pediatric and Emergency Dentistry.",
+  "items": {
+    "cleaning": "Cleaning & Teeth whitening",
+    "xray": "X-ray",
+    "orthodontic": "Orthodontic Treatment",
+    "bridge": "Dental Bridge",
+    "toothache": "Toothache relief",
+    "extraction": "Extraction",
+    "rootCanal": "Root Canal Treatment",
+    "consultation": "Check-ups and Consultation"
+  }
+}

--- a/src/i18n/locales/en/team.json
+++ b/src/i18n/locales/en/team.json
@@ -1,0 +1,12 @@
+{
+  "eyebrow": "Team",
+  "headline": "Meet Our Expert <hl>Team</hl>",
+  "subhead": "Our dedicated team of dental professionals is committed to providing you with the best dental care possible.",
+  "subheadExtra": "Each member of our team is highly skilled and experienced in their respective areas of expertise, ensuring that you receive personalized and high-quality treatment.",
+  "roles": {
+    "orthodontist": "Orthodontist",
+    "therapist": "Therapist",
+    "dentalSurgeon": "Dental Surgeon",
+    "assistant": "Assistant"
+  }
+}

--- a/src/i18n/locales/fr/faqs.json
+++ b/src/i18n/locales/fr/faqs.json
@@ -1,0 +1,25 @@
+{
+  "title": "Questions fréquentes",
+  "items": [
+    {
+      "question": "Quels services DentRw propose-t-il ?",
+      "answers": [
+        "DentRw propose un large éventail de services dentaires : soins préventifs, consultation virtuelle, détartrages, plombages, traitements de canal, extractions et plus encore. Notre équipe expérimentée s'engage à offrir des soins bucco-dentaires exceptionnels à ses patients."
+      ]
+    },
+    {
+      "question": "Quels sont les effets de la pratique traditionnelle appelée Gukura Ibyinyo / extraction des germes dentaires ?",
+      "answers": [
+        "Il est important de noter que l'extraction des germes dentaires peut avoir des effets graves et néfastes sur la santé bucco-dentaire. Les germes dentaires sont les dents immatures qui se développent encore sous la gencive chez l'enfant. Leur extraction perturbe l'éruption et l'alignement naturels des dents permanentes et entraîne divers problèmes dentaires.",
+        "Parmi les effets possibles : mauvais alignement des dents, dents incluses, problèmes d'occlusion et impact psychologique. Il est essentiel de privilégier des pratiques de soins fondées sur des données probantes."
+      ]
+    },
+    {
+      "question": "Comment prendre rendez-vous chez DentRw ?",
+      "answers": [
+        "Pour prendre rendez-vous chez DentRw, il vous suffit de remplir le formulaire ci-dessous et de l'envoyer.",
+        "En plus de notre système de réservation en ligne, vous pouvez aussi nous appeler. Nous proposons des horaires flexibles pour que vous puissiez recevoir les soins dont vous avez besoin au moment qui vous convient."
+      ]
+    }
+  ]
+}

--- a/src/i18n/locales/fr/services.json
+++ b/src/i18n/locales/fr/services.json
@@ -1,0 +1,15 @@
+{
+  "eyebrow": "Services",
+  "headline": "La gamme de <hl>services</hl> dentaires que nous proposons",
+  "subhead": "DentRw propose une gamme complète de services dentaires : dentisterie générale, esthétique, restauratrice, pédiatrique et d'urgence.",
+  "items": {
+    "cleaning": "Détartrage et blanchiment des dents",
+    "xray": "Radiographie",
+    "orthodontic": "Traitement orthodontique",
+    "bridge": "Bridge dentaire",
+    "toothache": "Soulagement des maux de dents",
+    "extraction": "Extraction",
+    "rootCanal": "Traitement de canal",
+    "consultation": "Examens et consultation"
+  }
+}

--- a/src/i18n/locales/fr/team.json
+++ b/src/i18n/locales/fr/team.json
@@ -1,0 +1,12 @@
+{
+  "eyebrow": "Équipe",
+  "headline": "Rencontrez notre équipe d'<hl>experts</hl>",
+  "subhead": "Notre équipe dévouée de professionnels dentaires s'engage à vous offrir les meilleurs soins dentaires possibles.",
+  "subheadExtra": "Chaque membre de notre équipe est hautement qualifié et expérimenté dans son domaine, pour vous garantir un traitement personnalisé et de haute qualité.",
+  "roles": {
+    "orthodontist": "Orthodontiste",
+    "therapist": "Thérapeute dentaire",
+    "dentalSurgeon": "Chirurgien-dentiste",
+    "assistant": "Assistante dentaire"
+  }
+}


### PR DESCRIPTION
## 📑 Description

i18n sweep, group 2 of 3.

- [x] `Services` — eyebrow, headline (`<Trans>` highlight), sub-copy, 8 service names; 8 near-duplicate `<li>`s are now a `.map` over `SERVICE_ITEMS`
- [x] `Team` — eyebrow, headline, sub-copy (+ the lg-only extra sentence), 4 role labels; member **names stay untranslated**, cards are a `.map` over `TEAM`
- [x] `FAQs` — title + 3 Q&A (answers as string arrays via `returnObjects`); the 3 hand-written `<details>` blocks are now a `.map`
- [x] `refactor(i18n)`: `src/i18n/index.js` auto-loads namespaces with `import.meta.glob("./locales/*/*.json")` — adding a namespace is now just two JSON files, no code edit (first commit)
- [x] `docs/i18n.md` updated

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

**Verified** in the browser in both languages — EN matches the original; FR renders translated service cards ("Détartrage et blanchiment des dents"…), team roles ("Chirurgien-dentiste"…), and FAQ Q&A. No missing-key warnings. Build / test (5) / lint / format green.

## ℹ Additional Information

- English carried over verbatim (typos included: `we offers`, `taditional`, `simpy`, `preventative`). French is clean.
- Minor markup normalisation in the `.map` conversions: all 8 service `<li>`s now use `bg-slate-200` (the last one had a stray `rounded-[4px]`, one `<h3>` lacked the hover classes); all Team photos get `alt={name}` (was `"avatar"` / `"Arriana avatar"`); all FAQ answer paragraphs use `px-4 pb-4`. No visible change.
- Group 3 (Contact / Footer / Testimonials chrome) is the last one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English and French translations for the Services, Team, and FAQs sections.
  * FAQ content now displays translated questions and answers dynamically.
  * Services and team information now adapt to the selected language.
  * Added localized team roles, service descriptions, appointment guidance, and dental information.

* **Documentation**
  * Updated internationalization documentation to reflect the expanded translation coverage and automatic locale loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->